### PR TITLE
Bundling: generate smaller, specialized bundles

### DIFF
--- a/index-cosmetics.ts
+++ b/index-cosmetics.ts
@@ -1,0 +1,1 @@
+export { default as CosmeticsInjection } from './src/cosmetics-injection';

--- a/index-matching.ts
+++ b/index-matching.ts
@@ -1,0 +1,4 @@
+export { default as ReverseIndex } from './src/reverse-index';
+export {default as matchNetworkFilter } from './src/matching/network';
+export { parseNetworkFilter } from './src/parsing/network-filter';
+export { mkRequest } from './src/request/interface';

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,11 @@
 export { default as CosmeticsInjection } from './src/cosmetics-injection';
-export { default as FiltersEngine, processRawRequest } from './src/filters-engine';
+export { default as FiltersEngine } from './src/filters-engine';
+export { processRawRequest } from './src/request/raw';
 export { deserializeEngine } from './src/serialization';
 
-export { matchNetworkFilter, matchCosmeticFilter } from './src/filters-matching';
+export {default as matchCosmeticFilter } from './src/matching/cosmetics';
+export {default as matchNetworkFilter } from './src/matching/network';
+
 export { default as ReverseIndex } from './src/reverse-index';
 
 export { parseCosmeticFilter } from './src/parsing/cosmetic-filter';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -40,21 +40,16 @@
       "integrity": "sha512-lthMj4kw7Fzs3LjBhQ0+1faAfDrN9GFJZO5Nf/xO7fppFfxqnnQdNR28n0xMGXsx8fTHOPliE1NTkAW1bVLpYw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1",
+        "@types/node": "9.3.0",
         "@types/tough-cookie": "2.3.2",
         "parse5": "3.0.3"
       }
     },
     "@types/node": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
-      "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
-    },
-    "@types/text-encoding": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/text-encoding/-/text-encoding-0.0.32.tgz",
-      "integrity": "sha512-kQ79aFmYcD/DR3QKo6wXyvNrKi7PunY0KYTBUhHjHl0SXwWuLRl9Leh73YtnsSJMBi9qSiK+fxWhdJNQPbhc9A=="
     },
     "@types/tough-cookie": {
       "version": "2.3.2",
@@ -92,20 +87,12 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
-          "dev": true
-        }
+        "acorn": "4.0.13"
       }
     },
     "ajv": {
@@ -680,7 +667,7 @@
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "browserify-sign": {
@@ -1006,7 +993,7 @@
         "inherits": "2.0.3",
         "pbkdf2": "3.0.14",
         "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "randomfill": "1.0.3"
       }
     },
@@ -1124,7 +1111,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "domexception": {
@@ -1389,9 +1376,6 @@
       "requires": {
         "locate-path": "2.0.0"
       }
-    },
-    "fnv-plus": {
-      "version": "git+https://git@github.com/tjwebb/fnv-plus.git#d2cd751c72b8f44762025e7b41902dfe61407974"
     },
     "for-in": {
       "version": "1.0.2",
@@ -2675,9 +2659,9 @@
       }
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -2867,7 +2851,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -2966,7 +2950,7 @@
             "chalk": "2.3.0",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
+            "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
@@ -2983,7 +2967,7 @@
             "jest-snapshot": "21.2.1",
             "jest-util": "21.2.1",
             "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
+            "node-notifier": "5.2.1",
             "pify": "3.0.0",
             "slash": "1.0.0",
             "string-length": "2.0.0",
@@ -3144,15 +3128,6 @@
         "jsdom": "9.12.0"
       },
       "dependencies": {
-        "acorn-globals": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-          "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-          "dev": true,
-          "requires": {
-            "acorn": "4.0.13"
-          }
-        },
         "jsdom": {
           "version": "9.12.0",
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
@@ -3185,30 +3160,6 @@
           "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
           "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
           "dev": true
-        },
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-          "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
-          "dev": true,
-          "requires": {
-            "tr46": "0.0.3",
-            "webidl-conversions": "3.0.1"
-          },
-          "dependencies": {
-            "webidl-conversions": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-              "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-              "dev": true
-            }
-          }
         }
       }
     },
@@ -3728,7 +3679,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -3741,7 +3692,7 @@
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
         "parse5": "3.0.3",
-        "pn": "1.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
@@ -3754,10 +3705,45 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+          "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.3.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "dev": true
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "dev": true,
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+          "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
         }
       }
     },
@@ -4317,13 +4303,13 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
         "growly": "1.3.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "shellwords": "0.1.1",
         "which": "1.3.0"
       }
@@ -4336,7 +4322,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -4486,10 +4472,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -4497,8 +4486,14 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.0",
@@ -4540,7 +4535,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.1"
+        "@types/node": "9.3.0"
       }
     },
     "path-exists": {
@@ -4627,9 +4622,9 @@
       }
     },
     "pn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "prelude-ls": {
@@ -4711,7 +4706,7 @@
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "randombytes": "2.0.6"
       }
     },
     "punycode": {
@@ -4767,9 +4762,9 @@
       }
     },
     "randombytes": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -4781,7 +4776,7 @@
       "integrity": "sha512-YL6GrhrWoic0Eq8rXVbMptH7dAxCs0J+mh5Y0euNekPPYaxEmdVGim6GdoxoRzKW2yJoU8tueifS7mYxvcFDEQ==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.5",
+        "randombytes": "2.0.6",
         "safe-buffer": "5.1.1"
       }
     },
@@ -4911,7 +4906,7 @@
         "stringstream": "0.0.5",
         "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "uuid": "3.2.1"
       }
     },
     "request-promise-core": {
@@ -4988,9 +4983,9 @@
       }
     },
     "rollup": {
-      "version": "0.52.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.52.1.tgz",
-      "integrity": "sha512-cVOL8rUMivChVcScL7zq1JCl4+4gMiVOllnX9r2l6MlkUzyXRbBK7szGDGaFXyqZl6uruFtX+gFhize9o7iiKg==",
+      "version": "0.54.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.54.1.tgz",
+      "integrity": "sha512-ebUUgUQ7K/sLn67CtO8Jj8H3RgKAoVWrpiJA7enOkwZPZzTCl8GC8CZ00g5jowjX80KgBmzs4Z1MV6cgglT86A==",
       "dev": true
     },
     "rollup-plugin-commonjs": {
@@ -4999,7 +4994,7 @@
       "integrity": "sha512-qK0+uhktmnAgZkHkqFuajNmPw93fjrO7+CysDaxWE5jrUR9XSlSvuao5ZJP+XizxA8weakhgYYBtbVz9SGBpjA==",
       "dev": true,
       "requires": {
-        "acorn": "5.2.1",
+        "acorn": "5.3.0",
         "estree-walker": "0.5.1",
         "magic-string": "0.22.4",
         "resolve": "1.5.0",
@@ -5007,9 +5002,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
+          "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
           "dev": true
         },
         "resolve": {
@@ -5150,13 +5145,13 @@
       "integrity": "sha1-Z7N60e/a+9g69MNrQMGJ7khmyWk=",
       "dev": true,
       "requires": {
-        "uglify-js": "3.2.2"
+        "uglify-js": "3.3.7"
       },
       "dependencies": {
         "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
         },
         "source-map": {
@@ -5166,12 +5161,12 @@
           "dev": true
         },
         "uglify-js": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.2.2.tgz",
-          "integrity": "sha512-++1NO/zZIEdWf6cDIGceSJQPX31SqIpbVAHwFG5+240MtZqPG/NIPoinj8zlXQtAfMBqEt1Jyv2FiLP3n9gVhQ==",
+          "version": "3.3.7",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.7.tgz",
+          "integrity": "sha512-esJIpNQIC44EFSrbeFPhiXHy2HJ+dTcnn0Zdkn+5meuLsvoV0mFJffKlyezNIIHNfhF0NpgbifygCfEyAogIhQ==",
           "dev": true,
           "requires": {
-            "commander": "2.12.2",
+            "commander": "2.13.0",
             "source-map": "0.6.1"
           }
         }
@@ -5238,9 +5233,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "set-blocking": {
@@ -5523,11 +5518,6 @@
         "require-main-filename": "1.0.1"
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-    },
     "throat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
@@ -5570,21 +5560,10 @@
       }
     },
     "tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
-          "dev": true
-        }
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "tree-kill": {
       "version": "1.2.0",
@@ -5613,14 +5592,14 @@
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
         "chalk": "2.3.0",
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "diff": "3.4.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
         "resolve": "1.5.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "tslib": "1.8.1",
-        "tsutils": "2.13.1"
+        "tsutils": "2.19.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5644,9 +5623,9 @@
           }
         },
         "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
           "dev": true
         },
         "has-flag": {
@@ -5676,9 +5655,9 @@
       }
     },
     "tsutils": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
-      "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.19.0.tgz",
+      "integrity": "sha512-qjgvrvtzRUtOmqlZTfBFtep6s+ymuBLsHOC4ee9JNA+AZIbnR/x4C2Y7QFhOGpD2R3lDp0BBcnxb0vnMVrU7Aw==",
       "dev": true,
       "requires": {
         "tslib": "1.8.1"
@@ -5774,9 +5753,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -5849,14 +5828,21 @@
       }
     },
     "whatwg-url": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
-      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+      "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
       "requires": {
-        "lodash.sortby": "4.7.0",
-        "tr46": "1.0.1",
-        "webidl-conversions": "4.0.2"
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "dev": true
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "concurrently": "3.5.1",
     "jest": "21.2.1",
     "jsdom": "11.5.1",
-    "rollup": "0.52.1",
+    "rollup": "0.54.1",
     "rollup-plugin-commonjs": "8.2.6",
     "rollup-plugin-json": "2.3.0",
     "rollup-plugin-node-builtins": "2.1.2",
@@ -45,9 +45,6 @@
     "typescript": "2.6.2"
   },
   "dependencies": {
-    "@types/text-encoding": "0.0.32",
-    "fnv-plus": "git+https://git@github.com/tjwebb/fnv-plus.git",
-    "text-encoding": "0.6.4",
     "tldjs": "2.2.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,32 +5,53 @@ import json from 'rollup-plugin-json';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 
-export default {
-  input: './build/es6/index.js',
-  output: {
-    file: 'adblocker.umd.js',
-    name: 'adblocker',
-    format: 'umd',
-  },
-  plugins: [
-    globals(),
-    builtins(),
-    sourcemaps(),
-    json(),
-
-    nodeResolve({
-      jsnext: true,
-      main: true,
-      browser: true,
-    }),
-
-    commonjs({
-      extensions: [ '.js', '.json' ],
-      namedExports: {
-        'tldjs/index.js': [ 'parse', 'getPublicSuffix' ],
-        'fnv-plus/index.js': [ 'fast1a32' ],
-        'text-encoding/index.js': [ 'TextEncoder', 'TextDecoder' ],
-      },
-    }),
-  ]
+const namedExports = {
+      'tldjs/index.js': [ 'parse', 'getPublicSuffix' ],
 };
+
+const plugins = [
+  globals(),
+  builtins(),
+  sourcemaps(),
+  json(),
+
+  nodeResolve({
+    jsnext: true,
+    main: true,
+    browser: true,
+  }),
+
+  commonjs({
+    extensions: [ '.js', '.json' ],
+    namedExports,
+  }),
+];
+
+export default [
+  {
+    input: './build/es6/index-cosmetics.js',
+    output: {
+      file: 'adblocker-cosmetics.umd.js',
+      name: 'adblocker',
+      format: 'umd',
+    },
+    plugins,
+  },
+  {
+    input: './build/es6/index-matching.js',
+    output: {
+      file: 'pattern-matching.es',
+      format: 'es',
+    },
+    plugins,
+  },
+  {
+    input: './build/es6/index.js',
+    output: {
+      file: 'adblocker.umd.js',
+      name: 'adblocker',
+      format: 'umd',
+    },
+    plugins,
+  },
+];

--- a/src/dynamic-data-view.ts
+++ b/src/dynamic-data-view.ts
@@ -1,4 +1,4 @@
-import { TextDecoder, TextEncoder } from 'text-encoding';
+import { decode, encode } from './encoding';
 
 /**
  * @class DynamicDataView
@@ -71,7 +71,7 @@ export default class DynamicDataView {
   }
 
   public pushUTF8(str: string): void {
-    const buffer = new TextEncoder().encode(str);
+    const buffer = encode(str);
     this.pushUint16(buffer.byteLength);
     this.pushBytes(buffer);
   }
@@ -148,7 +148,7 @@ export default class DynamicDataView {
   }
 
   public getUTF8(): string {
-    return new TextDecoder().decode(this.getBytes(this.getUint16()));
+    return decode(this.getBytes(this.getUint16()));
   }
 
   public getStr(): string {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,0 +1,20 @@
+function fromString(str: string): Uint8Array {
+  const res = new Uint8Array(str.length);
+  const len = str.length;
+  for (let i = 0; i < len; i += 1) {
+    res[i] = str.charCodeAt(i);
+  }
+  return res;
+}
+
+declare function escape(s: string): string;
+declare function unescape(s: string): string;
+
+// http://ecmanaut.blogspot.de/2006/07/encoding-decoding-utf8-in-javascript.html
+export function encode(s: string): Uint8Array {
+  return fromString(unescape(encodeURIComponent(s)));
+}
+
+export function decode(bytes: Uint8Array): string {
+  return decodeURIComponent(escape(String.fromCharCode.apply(null, bytes)));
+}

--- a/src/matching/cosmetics.ts
+++ b/src/matching/cosmetics.ts
@@ -1,0 +1,75 @@
+import { getPublicSuffix } from 'tldjs';
+import { CosmeticFilter } from '../parsing/cosmetic-filter';
+import { fastStartsWith } from '../utils';
+
+/* Checks that hostnamePattern matches at the end of the hostname.
+ * Partial matches are allowed, but hostname should be a valid
+ * subdomain of hostnamePattern.
+ */
+function checkHostnamesPartialMatch(
+  hostname: string,
+  hostnamePattern: string,
+): boolean {
+  let pattern = hostnamePattern;
+  if (fastStartsWith(hostnamePattern, '~')) {
+    pattern = pattern.substr(1);
+  }
+
+  if (hostname.endsWith(pattern)) {
+    const patternIndex = hostname.length - pattern.length;
+    if (patternIndex === 0 || hostname[patternIndex - 1] === '.') {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/* Checks if `hostname` matches `hostnamePattern`, which can appear as
+ * a domain selector in a cosmetic filter: hostnamePattern##selector
+ *
+ * It takes care of the concept of entities introduced by uBlock: google.*
+ * https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#entity-based-cosmetic-filters
+ */
+function matchHostname(hostname: string, hostnamePattern: string): boolean {
+  if (hostnamePattern.endsWith('.*')) {
+    // Match entity:
+    const entity = hostnamePattern.slice(0, -2);
+
+    // Ignore TLDs suffix
+    const publicSuffix = getPublicSuffix(hostname);
+    const hostnameWithoutSuffix = hostname.substr(
+      0,
+      hostname.length - publicSuffix.length - 1,
+    );
+
+    if (hostnameWithoutSuffix.length > 0) {
+      // Check if we have a match
+      return checkHostnamesPartialMatch(hostnameWithoutSuffix, entity);
+    }
+
+    return false;
+  }
+
+  return checkHostnamesPartialMatch(hostname, hostnamePattern);
+}
+
+export default function matchCosmeticFilter(
+  filter: CosmeticFilter,
+  hostname: string,
+): { hostname: string } | null {
+  // Check hostnames
+  if (filter.hasHostnames() && hostname) {
+    const hostnames = filter.getHostnames();
+    for (let i = 0; i < hostnames.length; i += 1) {
+      if (matchHostname(hostname, hostnames[i])) {
+        return { hostname: hostnames[i] };
+      }
+    }
+
+    // No hostname match
+    return null;
+  }
+
+  return { hostname: '' };
+}

--- a/src/matching/network.ts
+++ b/src/matching/network.ts
@@ -1,7 +1,5 @@
-import { getPublicSuffix } from 'tldjs';
-import { CosmeticFilter } from './parsing/cosmetic-filter';
-import { NetworkFilter } from './parsing/network-filter';
-import { fastStartsWith } from './utils';
+import { NetworkFilter } from '../parsing/network-filter';
+import { fastStartsWith } from '../utils';
 
 function isAnchoredByHostname(
   filterHostname: string,
@@ -175,78 +173,6 @@ function checkOptions(filter: NetworkFilter, request): boolean {
   return true;
 }
 
-export function matchNetworkFilter(filter: NetworkFilter, request): boolean {
+export default function matchNetworkFilter(filter: NetworkFilter, request): boolean {
   return checkOptions(filter, request) && checkPattern(filter, request);
-}
-
-/* Checks that hostnamePattern matches at the end of the hostname.
- * Partial matches are allowed, but hostname should be a valid
- * subdomain of hostnamePattern.
- */
-function checkHostnamesPartialMatch(
-  hostname: string,
-  hostnamePattern: string,
-): boolean {
-  let pattern = hostnamePattern;
-  if (fastStartsWith(hostnamePattern, '~')) {
-    pattern = pattern.substr(1);
-  }
-
-  if (hostname.endsWith(pattern)) {
-    const patternIndex = hostname.length - pattern.length;
-    if (patternIndex === 0 || hostname[patternIndex - 1] === '.') {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/* Checks if `hostname` matches `hostnamePattern`, which can appear as
- * a domain selector in a cosmetic filter: hostnamePattern##selector
- *
- * It takes care of the concept of entities introduced by uBlock: google.*
- * https://github.com/gorhill/uBlock/wiki/Static-filter-syntax#entity-based-cosmetic-filters
- */
-function matchHostname(hostname: string, hostnamePattern: string): boolean {
-  if (hostnamePattern.endsWith('.*')) {
-    // Match entity:
-    const entity = hostnamePattern.slice(0, -2);
-
-    // Ignore TLDs suffix
-    const publicSuffix = getPublicSuffix(hostname);
-    const hostnameWithoutSuffix = hostname.substr(
-      0,
-      hostname.length - publicSuffix.length - 1,
-    );
-
-    if (hostnameWithoutSuffix.length > 0) {
-      // Check if we have a match
-      return checkHostnamesPartialMatch(hostnameWithoutSuffix, entity);
-    }
-
-    return false;
-  }
-
-  return checkHostnamesPartialMatch(hostname, hostnamePattern);
-}
-
-export function matchCosmeticFilter(
-  filter: CosmeticFilter,
-  hostname: string,
-): { hostname: string } | null {
-  // Check hostnames
-  if (filter.hasHostnames() && hostname) {
-    const hostnames = filter.getHostnames();
-    for (let i = 0; i < hostnames.length; i += 1) {
-      if (matchHostname(hostname, hostnames[i])) {
-        return { hostname: hostnames[i] };
-      }
-    }
-
-    // No hostname match
-    return null;
-  }
-
-  return { hostname: '' };
 }

--- a/src/request/interface.ts
+++ b/src/request/interface.ts
@@ -1,0 +1,36 @@
+import { tokenize } from '../utils';
+
+export interface IRequest {
+  url: string;
+  tokens: number[];
+  hostGD: string;
+  hostname: string;
+
+  sourceGD: string;
+  sourceHostname: string;
+
+  cpt: number;
+}
+
+export function mkRequest({
+  url = '',
+  hostname = '',
+  domain = '',
+  sourceHostname = '',
+  sourceDomain = '',
+  cpt = 6 },
+): IRequest {
+  return {
+    cpt,
+    tokens: tokenize(url),
+
+    // SourceUrl
+    sourceGD: sourceDomain,
+    sourceHostname,
+
+    // Url
+    hostGD: domain,
+    hostname,
+    url: url.toLowerCase(),
+  };
+}

--- a/src/request/raw.ts
+++ b/src/request/raw.ts
@@ -1,0 +1,43 @@
+import { parse } from 'tldjs';
+import { mkRequest } from './interface';
+
+export interface IRawRequest {
+  url: string;
+  sourceUrl: string;
+  cpt: number;
+}
+
+export function processRawRequest(request: IRawRequest) {
+  // Extract hostname
+  const url = request.url.toLowerCase();
+  const { hostname, domain } = parse(url);
+
+  // Process source url
+  let sourceUrl = request.sourceUrl;
+  let sourceHostname = '';
+  let sourceDomain = '';
+
+  if (sourceUrl) {
+    // It can happen when source is not a valid URL, then we simply
+    // leave `sourceHostname` and `sourceGD` as empty strings to allow
+    // some filter matching on the request URL itself.
+    sourceUrl = sourceUrl.toLowerCase();
+    const sourceUrlParts = parse(sourceUrl);
+    sourceHostname = sourceUrlParts.hostname || '';
+    sourceDomain = sourceUrlParts.domain || '';
+  }
+
+  // Wrap informations needed to match the request
+  return mkRequest({
+    cpt: request.cpt,
+
+    // SourceUrl
+    sourceDomain,
+    sourceHostname,
+
+    // Url
+    domain,
+    hostname,
+    url,
+  });
+}

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -1,8 +1,10 @@
 import {} from 'jest';
 
-import { matchCosmeticFilter, matchNetworkFilter } from '../src/filters-matching';
+import matchCosmeticFilter from '../src/matching/cosmetics';
+import matchNetworkFilter from '../src/matching/network';
+
 import { f } from '../src/parsing/list';
-import { processRawRequest } from '../src/filters-engine';
+import { processRawRequest } from '../src/request/raw';
 
 expect.extend({
   toMatchRequest(filter, request) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,8 +1,12 @@
 import {} from 'jest';
 
 import { parseList } from '../src/parsing/list';
-import { tokenize, tokenizeCSS } from '../src/utils';
+import { fastHash, tokenize, tokenizeCSS } from '../src/utils';
 import { loadAllLists } from './utils';
+
+function t(tokens) {
+  return tokens.map(fastHash);
+}
 
 expect.extend({
   toNotCollideWithOtherFilter(filter: { id: number }, map) {
@@ -46,16 +50,16 @@ describe('Utils', () => {
   });
 
   it('#tokenize', () => {
-    expect(tokenize('', false)).toEqual([]);
-    expect(tokenize('foo', false)).toEqual(['foo']);
-    expect(tokenize('foo/bar', false)).toEqual(['foo', 'bar']);
-    expect(tokenize('foo-bar', false)).toEqual(['foo', 'bar']);
-    expect(tokenize('foo.bar', false)).toEqual(['foo', 'bar']);
+    expect(tokenize('')).toEqual(t([]));
+    expect(tokenize('foo')).toEqual(t(['foo']));
+    expect(tokenize('foo/bar')).toEqual(t(['foo', 'bar']));
+    expect(tokenize('foo-bar')).toEqual(t(['foo', 'bar']));
+    expect(tokenize('foo.bar')).toEqual(t(['foo', 'bar']));
   });
 
   it('#tokenizeCSS', () => {
-    expect(tokenizeCSS('', false)).toEqual([]);
-    expect(tokenizeCSS('.selector', false)).toEqual(['.selector']);
-    expect(tokenizeCSS('.selector-foo', false)).toEqual(['.selector-foo']);
+    expect(tokenizeCSS('')).toEqual([]);
+    expect(tokenizeCSS('.selector')).toEqual(t(['.selector']));
+    expect(tokenizeCSS('.selector-foo')).toEqual(t(['.selector-foo']));
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "pretty": true,
     "sourceMap": true,
     "noImplicitAny": false,
-    "removeComments": false
+    "removeComments": true
   },
   "exclude": [
     "node_modules",
@@ -23,6 +23,8 @@
   ],
   "files": [
     "./index.ts",
+    "./index-cosmetics.ts",
+    "./index-matching.ts",
     "test/engine.test.ts",
     "test/injection.test.ts",
     "test/matching.test.js",


### PR DESCRIPTION
This PR aims at generating several, specialized bundles to be used in different context.

- `pattern-matching.es` can be used if you want to re-use the pattern matching capabilities of the adblocker.
- `adblocker-cosmetics.umd.js` only contains the cosmetics part
- `adblocker.umd.js` contains everything.

I also got rid of `text-encoding` and `fnv-hash` deps to not make the bundles bigger than necessary.