### PR TITLE
Fix network filter toString

### DIFF
--- a/src/parsing/network-filter.ts
+++ b/src/parsing/network-filter.ts
@@ -209,11 +209,12 @@ export class NetworkFilter {
       filter += '|';
     }
 
+    if (this.hasHostname()) {
+      filter += this.getHostname();
+      filter += '^';
+    }
+
     if (!this.isRegex()) {
-      if (this.hasHostname()) {
-        filter += this.getHostname();
-        filter += '^';
-      }
       filter += this.getFilter();
     } else {
       // Visualize the compiled regex


### PR DESCRIPTION
`toString` was ignoring the hostname of regex filters.