### PR TITLE
Fix the sperator in network filter matching

### DIFF
--- a/example/rollup.background.js
+++ b/example/rollup.background.js
@@ -1,8 +1,9 @@
 import config from '../rollup.config.js';
 
+const fullConfig = config[2];
 
 export default {
-  ...config,
+  ...fullConfig,
   input: './build/example/background.js',
   output: {
     file: 'background.bundle.js',

--- a/example/rollup.content.js
+++ b/example/rollup.content.js
@@ -1,8 +1,9 @@
 import config from '../rollup.config.js';
 
+const fullConfig = config[2];
 
 export default {
-  ...config,
+  ...fullConfig,
   input: './build/example/content-script.js',
   output: {
     file: 'content-script.bundle.js',

--- a/src/matching/network.ts
+++ b/src/matching/network.ts
@@ -12,6 +12,13 @@ function isAnchoredByHostname(
   );
 }
 
+function getUrlAfterHostname(
+  url: string,
+  hostname: string,
+): string {
+  return url.substring(url.indexOf(hostname) + hostname.length);
+}
+
 // pattern
 function checkPatternPlainFilter(filter: NetworkFilter, { url }): boolean {
   return url.indexOf(filter.getFilter()) !== -1;
@@ -50,8 +57,8 @@ function checkPatternHostnameAnchorRegexFilter(
 ): boolean {
   if (isAnchoredByHostname(filter.getHostname(), hostname)) {
     // remove the hostname and use the rest to match the pattern
-    const urlPath: string = url.substring(url.indexOf(hostname) + hostname.length);
-    return checkPatternRegexFilter(filter, { url: urlPath });
+    const urlAfterHostname = getUrlAfterHostname(url, filter.getHostname());
+    return checkPatternRegexFilter(filter, { url: urlAfterHostname });
   }
 
   return false;
@@ -66,9 +73,7 @@ function checkPatternHostnameRightAnchorFilter(
     // Since this is not a regex, the filter pattern must follow the hostname
     // with nothing in between. So we extract the part of the URL following
     // after hostname and will perform the matching on it.
-    const urlAfterHostname = url.substring(
-      url.indexOf(filter.getHostname()) + filter.getHostname().length,
-    );
+    const urlAfterHostname = getUrlAfterHostname(url, filter.getHostname());
 
     // Since it must follow immediatly after the hostname and be a suffix of
     // the URL, we conclude that filter must be equal to the part of the
@@ -88,9 +93,7 @@ function checkPatternHostnameAnchorFilter(
     // Since this is not a regex, the filter pattern must follow the hostname
     // with nothing in between. So we extract the part of the URL following
     // after hostname and will perform the matching on it.
-    const urlAfterHostname = url.substring(
-      url.indexOf(filter.getHostname()) + filter.getHostname().length,
-    );
+    const urlAfterHostname = getUrlAfterHostname(url, filter.getHostname());
 
     // Otherwise, it should only be a prefix of the URL.
     return fastStartsWith(urlAfterHostname, filter.getFilter());

--- a/src/matching/network.ts
+++ b/src/matching/network.ts
@@ -49,7 +49,9 @@ function checkPatternHostnameAnchorRegexFilter(
   { url, hostname },
 ): boolean {
   if (isAnchoredByHostname(filter.getHostname(), hostname)) {
-    return checkPatternRegexFilter(filter, { url });
+    // remove the hostname and use the rest to match the pattern
+    const urlPath: string = url.substring(url.indexOf(hostname) + hostname.length);
+    return checkPatternRegexFilter(filter, { url: urlPath });
   }
 
   return false;

--- a/test/matching.test.js
+++ b/test/matching.test.js
@@ -96,6 +96,10 @@ describe('#matchNetworkFilter', () => {
   it('|pattern|', () => {
     expect(f`|https://foo.com|`).toMatchRequest({ url: 'https://foo.com' });
   });
+
+  it('||hostname^*/pattern', () => {
+    expect(f`||foo.com^*/bar`).not.toMatchRequest({ url: 'https://foo.com/bar' });
+  });
 });
 
 describe('#matchCosmeticFilter', () => {


### PR DESCRIPTION
This pattern `||hostname^*/pattern` will now match properly