### PR TITLE
avoid force layout

### DIFF
--- a/src/cosmetics-injection.ts
+++ b/src/cosmetics-injection.ts
@@ -214,7 +214,7 @@ export default class CosmeticInjection {
         const node = nodes[i] as HTMLElement;
 
         // Ignore hidden nodes
-        if (node.hidden || node.offsetWidth === 0 && node.offsetHeight === 0) {
+        if (node.hidden) {
           continue;
         }
 


### PR DESCRIPTION
Avoid calling elements that force css layout, so the page load does not blink. In the worse case, we will inject a few more unnecessary cosmetic filters