### PR TITLE
cosmetics: handle null or empty public suffix while matching hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *unreleased*
 
+  * Handle falsy publicSuffix in cosmetic filters matching [#19](https://github.com/cliqz-oss/adblocker/pull/19)
   * Network filter matching handle empty hostname [#18](https://github.com/cliqz-oss/adblocker/pull/18)
   * Update dependencies to fix node.js 10 build [#17](https://github.com/cliqz-oss/adblocker/pull/17)
 

--- a/src/matching/cosmetics.ts
+++ b/src/matching/cosmetics.ts
@@ -40,6 +40,10 @@ function matchHostname(hostname: string, hostnamePattern: string): boolean {
 
     // Ignore TLDs suffix
     const publicSuffix = getPublicSuffix(hostname);
+    if (!publicSuffix) {
+      return false;
+    }
+
     const hostnameWithoutSuffix = hostname.substr(
       0,
       hostname.length - publicSuffix.length - 1,


### PR DESCRIPTION
This should fix things like:
> Process Script adblocker/getCosmeticsForNodes TypeError: publicSuffix is null