### PR TITLE
Produce a commonjs build artifact

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6829,8 +6829,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "author": "Cliqz",
   "license": "MPL-2.0",
-  "main": "dist/adblocker.umd.min.js",
+  "main": "dist/adblocker.cjs.js",
+  "browser": "dist/adblocker.umd.js",
   "module": "dist/adblocker.es.js",
   "jsnext:main": "dist/adblocker.es.js",
   "types": "dist/index.d.ts",
@@ -52,6 +53,7 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "tldts": "^3.0.0"
+    "tldts": "^3.0.0",
+    "tslib": "^1.9.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -31,6 +31,14 @@ export default [
   {
     input: './build/index.js',
     output: {
+      file: './dist/adblocker.cjs.js',
+      name: 'adblocker',
+      format: 'cjs',
+    },
+  },
+  {
+    input: './build/index.js',
+    output: {
       file: './dist/adblocker.umd.js',
       name: 'adblocker',
       format: 'umd',


### PR DESCRIPTION
This PR adds an extra bundle in commonjs format, this can be useful if `adblocker` is to be used as part of a project having its own bundle.