### PR TITLE
Add support for CSP (Content Security Policy) filters

### DIFF
--- a/src/dynamic-data-view.ts
+++ b/src/dynamic-data-view.ts
@@ -76,6 +76,17 @@ export default class DynamicDataView {
     this.pushBytes(buffer);
   }
 
+  public pushUint32Array(arr: Uint32Array | undefined): void {
+    if (arr === undefined) {
+      this.pushUint16(0);
+    } else {
+      this.pushUint16(arr.length);
+      for (let i = 0; i < arr.length; i += 1) {
+        this.pushUint32(arr[i]);
+      }
+    }
+  }
+
   /**
    * This method is very optimistic and will assume that by default every string
    * is ascii only, but fallback to a slower utf-8 method if a non-ascii char is
@@ -154,7 +165,7 @@ export default class DynamicDataView {
     return decode(this.getBytes(this.getUint16()));
   }
 
-  public getStr(): string {
+  public getStr(): string | undefined {
     // Keep track of original position to be able to fallback
     // to getUTF8 if we encounter non-ascii characters.
     const originalPos = this.pos;
@@ -162,7 +173,7 @@ export default class DynamicDataView {
 
     // Special handling for empty strings
     if (size === 0) {
-      return '';
+      return undefined;
     }
 
     // Check if there is a non-ascii character in the string.
@@ -177,6 +188,18 @@ export default class DynamicDataView {
     }
 
     return String.fromCharCode.apply(null, this.getBytes(size));
+  }
+
+  public getUint32Array(): Uint32Array | undefined {
+    const length = this.getUint16();
+    if (length > 0) {
+      const arr = new Uint32Array(length);
+      for (let i = 0; i < length; i += 1) {
+        arr[i] = this.getUint32();
+      }
+      return arr;
+    }
+    return undefined;
   }
 
   private checkShouldResize(n: number): void {

--- a/src/engine/list.ts
+++ b/src/engine/list.ts
@@ -5,6 +5,7 @@ export default interface IList {
   checksum: string;
   cosmetics: CosmeticFilter[];
   exceptions: NetworkFilter[];
+  csp: NetworkFilter[];
   filters: NetworkFilter[];
   importants: NetworkFilter[];
   redirects: NetworkFilter[];

--- a/src/engine/optimizer.ts
+++ b/src/engine/optimizer.ts
@@ -107,7 +107,9 @@ const OPTIMIZATIONS: IOptimization[] = [
     groupByCriteria: (filter: NetworkFilter) =>
       filter.getHostname() + filter.getFilter() + filter.getMask() + filter.getRedirect(),
     select: (filter: NetworkFilter) =>
-      !filter.isFuzzy() && (filter.hasOptDomains() || filter.hasOptNotDomains()),
+      !filter.isFuzzy() &&
+      !filter.isCSP() &&
+      (filter.hasOptDomains() || filter.hasOptNotDomains()),
   },
   {
     description: 'Group simple patterns, into a single filter',
@@ -147,7 +149,8 @@ const OPTIMIZATIONS: IOptimization[] = [
       !filter.hasOptDomains() &&
       !filter.hasOptNotDomains() &&
       !filter.isHostnameAnchor() &&
-      !filter.isRedirect(),
+      !filter.isRedirect() &&
+      !filter.isCSP(),
   },
 ];
 

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -14,8 +14,10 @@ function network(filter: string, expected: any) {
       optDomains: parsed.getOptDomains(),
       optNotDomains: parsed.getOptNotDomains(),
       redirect: parsed.getRedirect(),
+      csp: parsed.csp,
 
       // Filter type
+      isCSP: parsed.isCSP(),
       isException: parsed.isException(),
       isHostnameAnchor: parsed.isHostnameAnchor(),
       isLeftAnchor: parsed.isLeftAnchor(),
@@ -52,6 +54,7 @@ function network(filter: string, expected: any) {
 
 const DEFAULT_NETWORK_FILTER = {
   // Attributes
+  csp: undefined,
   filter: '',
   hostname: '',
   optDomains: new Uint32Array([]),
@@ -59,6 +62,7 @@ const DEFAULT_NETWORK_FILTER = {
   redirect: '',
 
   // Filter type
+  isCSP: false,
   isException: false,
   isHostnameAnchor: false,
   isLeftAnchor: false,
@@ -411,6 +415,37 @@ describe('Network filters', () => {
 
       it('defaults to false', () => {
         network('||foo.com', { isImportant: false });
+      });
+    });
+
+    describe('csp', () => {
+      it('defaults to no csp', () => {
+        network('||foo.com', {
+          csp: undefined,
+          isCSP: false,
+        });
+      });
+
+      it('parses simple csp', () => {
+        network('||foo.com$csp=self bar ""', {
+          csp: 'self bar ""',
+          isCSP: true,
+        });
+      });
+
+      it('parses empty csp', () => {
+        network('||foo.com$csp', {
+          csp: undefined,
+          isCSP: true,
+        });
+      });
+
+      it('parses csp mixed with other options', () => {
+        network('||foo.com$domain=foo|bar,csp=self bar "",image', {
+          csp: 'self bar ""',
+          fromImage: true,
+          isCSP: true,
+        });
       });
     });
 


### PR DESCRIPTION
- [x] Add support for `csp` option in filters
- [x] Add support for matching `csp` filters on Engine
- [x] Add serialization logic for `csp` filters
- [x] Add tests for `Engine.getCSPDirectives` method
- [x] Update test extension with CSPs support (`onHeadersReceived` hook needed)