### PR TITLE
Fix fuzzy matching by allowing tokens of any size

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,7 +207,7 @@ export function tokenizeCSS(pattern: string): Uint32Array {
 }
 
 export function createFuzzySignature(pattern: string): Uint32Array {
-  return compactTokens(new Uint32Array(tokenize(pattern)));
+  return compactTokens(new Uint32Array(fastTokenizer(pattern, isAllowed)));
 }
 
 export function binSearch(arr: Uint32Array, elt: number): boolean {

--- a/test/matching.test.ts
+++ b/test/matching.test.ts
@@ -173,6 +173,7 @@ describe('#matchNetworkFilter', () => {
   });
 
   it('pattern$fuzzy', () => {
+    expect(f`f$fuzzy`).toMatchRequest({ url: 'https://bar.com/f' });
     expect(f`foo$fuzzy`).toMatchRequest({ url: 'https://bar.com/foo' });
     expect(f`foo$fuzzy`).toMatchRequest({ url: 'https://bar.com/foo/baz' });
     expect(f`foo/bar$fuzzy`).toMatchRequest({ url: 'https://bar.com/foo/baz' });


### PR DESCRIPTION
This bug was introduced while optimizing tokenizers for network filters (for which we disallow tokens of size 1); this limitation should not apply to fuzzy filter signatures.