### PR TITLE
Release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Next
 
-*not released*
+*not released yet*
 
+## 0.3.1
+
+*2018-11-29*
+
+  * Fix fuzzy matching by allowing tokens of any size [#61](https://github.com/cliqz-oss/adblocker/pull/62)
+  * Add support for CSP (Content Security Policy) filters [#60](https://github.com/cliqz-oss/adblocker/pull/60)
   * Add hard-coded circumvention logic (+ IL defuser) [#59](https://github.com/cliqz-oss/adblocker/pull/59)
     - Simplify 'example' extension
     - Add circumvention module and entry-point in cosmetics injection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Fix fuzzy matching by allowing tokens of any size [#61](https://github.com/cliqz-oss/adblocker/pull/62)
* Add support for CSP (Content Security Policy) filters [#60](https://github.com/cliqz-oss/adblocker/pull/60)
* Add hard-coded circumvention logic (+ IL defuser) [#59](https://github.com/cliqz-oss/adblocker/pull/59)
  - Simplify 'example' extension
  - Add circumvention module and entry-point in cosmetics injection
  - Clean-up cjs and esm bundles
  - Remove obsolete logic to override user-agent in content-script
  - Simplify travis config (using new pre* hooks)
  - Consolidate 'fetch' module (with metadata about lists)

