### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 *not released yet*
 
+## 0.4.0
+
+*2018-12-04*
+
+  * Fix serialization to include CSP bucket [#69](https://github.com/cliqz-oss/adblocker/pull/69)
+    * [BREAKING] `NetworkFilterBucket` and `ReverseIndex` now expect different arguments
+
 ## 0.3.2
 
 *2018-12-04*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Fix serialization to include CSP bucket [#69](https://github.com/cliqz-oss/adblocker/pull/69)
  * [BREAKING] `NetworkFilterBucket` and `ReverseIndex` now expect different arguments

