### PR TITLE
Fix cosmetics injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 *not released yet*
 
+  * Fix cosmetics injection [#79](https://github.com/cliqz-oss/adblocker/pull/79)
+    * Ignore cosmetic filters with extended syntax
+    * Ignore invalid cosmetic filters (using strict validation)
+    * Make use of tabs.insertCSS to inject style from background
+  * Update dependencies [#78](https://github.com/cliqz-oss/adblocker/pull/78)
+  * Harden typescript + simplify cosmetic injection [#71](https://github.com/cliqz-oss/adblocker/pull/71)
+  * Add support for Ghostery rules [#73](https://github.com/cliqz-oss/adblocker/pull/73)
+    * Add support for `bug` filter attribute
+    * Exceptions can now match filters with `bug` option
+    * Simplify and speed-up serialization for network filters
+    * Fix hostname anchor matching by preventing infix match in some corner case
+
 ## 0.4.1
 
 *2018-12-12*
@@ -14,11 +26,6 @@
 
 *2018-12-04*
 
-  * Add support for Ghostery rules [#73](https://github.com/cliqz-oss/adblocker/pull/73)
-    * Add support for `bug` filter attribute
-    * Exceptions can now match filters with `bug` option
-    * Simplify and speed-up serialization for network filters
-    * Fix hostname anchor matching by preventing infix match in some corner case
   * Fix serialization to include CSP bucket [#69](https://github.com/cliqz-oss/adblocker/pull/69)
     * [BREAKING] `NetworkFilterBucket` and `ReverseIndex` now expect different arguments
 

--- a/example/content-script.ts
+++ b/example/content-script.ts
@@ -33,7 +33,6 @@ const getCosmeticsFilters = (): Promise<IMessageFromBackground> => {
  * side. It handles the following:
  * - Inject scripts into the page, which might be used to defuse anti-adblockers.
  * - Block the execution of some scripts in the page (only if the
- * 'beforescriptexecute' event is avaliable, currently only on Firefox).
- * - Inject CSS styles (cosmetics) to hide ads or remove empty placeholders.
+ * 'beforescriptexecute' event is available, currently only on Firefox).
  */
 injectCosmetics(window, getCosmeticsFilters);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5620,9 +5620,9 @@
       }
     },
     "rollup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.0.0.tgz",
-      "integrity": "sha512-LV6Qz+RkuDAfxr9YopU4k5o5P/QA7YNq9xi2Ug2IqOmhPt9sAm89vh3SkNtFok3bqZHX54eMJZ8F68HPejgqtw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.0.1.tgz",
+      "integrity": "sha512-jf1EA9xJMx4hgEVdJQd8lVo2a0gbzY7fKM9kHZwQzcafYDapwLijd9G56Kxm2/RdEnQUEw9mSv8PyRWhsV0x2A==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "google-closure-compiler": "^20181210.0.0",
     "jest": "^23.6.0",
     "jsdom": "^13.1.0",
-    "rollup": "^1.0.0",
+    "rollup": "^1.0.1",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
     "ts-jest": "^23.10.5",

--- a/src/cosmetics-injection.ts
+++ b/src/cosmetics-injection.ts
@@ -35,17 +35,21 @@ export default function injectCosmetics(
       }
 
       // Inject scripts
-      for (let i = 0; i < scripts.length; i += 1) {
-        injectScript(scripts[i], window.document);
+      if (scripts) {
+        for (let i = 0; i < scripts.length; i += 1) {
+          injectScript(scripts[i], window.document);
+        }
       }
 
       // Block scripts
-      for (let i = 0; i < blockedScripts.length; i += 1) {
-        blockScript(blockedScripts[i], window.document);
+      if (blockedScripts) {
+        for (let i = 0; i < blockedScripts.length; i += 1) {
+          blockScript(blockedScripts[i], window.document);
+        }
       }
 
       // Inject CSS
-      if (styles.length > 0) {
+      if (styles && styles.length > 0) {
         injectCSSRule(`${styles.join(',')} { display: none!important; }`, window.document);
       }
     },


### PR DESCRIPTION
- Ignore cosmetic filters with extended syntax
- Ignore invalid cosmetic filters (using strict validation)
- Make use of `tabs.insertCSS` to inject style from background