### PR TITLE
Remove tldts dependency and allow to plug any implementation instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 *not released yet*
 
+  * Remove tldts dependency and allow to plug any implementation instead [#81](https://github.com/cliqz-oss/adblocker/pull/81)
+    * Adblocker does not include tldts by default anymore
+    * APIs now expect either already constructed Request as arguments of both
+      hostname and domain when needed (e.g.: getCosmeticsFilters)
+    * A makeRequest helper is provided to construct Request objects
+    * [BREAKING] engine.match expects a `Request` as argument
+    * [BREAKING] engine.matchAll expects a `Request` as argument
+    * [BREAKING] engine.getCSPDirectives expects a `Request` as argument
+    * [BREAKING] engine.getCosmeticsFilter expects a new `domain` argument
+    * [BREAKING] `Request`'s constructor does not apply default value
+      anymore and expects all arguments to be provided and initialized. You
+      can now use `makeRequest` to reproduce the previous behavior of `new
+      Request`.
   * Fix cosmetics injection [#79](https://github.com/cliqz-oss/adblocker/pull/79)
     * Ignore cosmetic filters with extended syntax
     * Ignore invalid cosmetic filters (using strict validation)

--- a/example/background.ts
+++ b/example/background.ts
@@ -1,3 +1,4 @@
+import { getDomain, getHostname } from 'tldts';
 import * as adblocker from '../index';
 
 /**
@@ -96,11 +97,14 @@ function requestFromDetails({
   if (tabs.has(tabId)) {
     source = tabs.get(tabId).source;
   }
-  return {
-    sourceUrl: source,
-    type,
-    url,
-  };
+  return adblocker.makeRequest(
+    {
+      sourceUrl: source,
+      type,
+      url,
+    },
+    { getDomain, getHostname },
+  );
 }
 
 loadAdblocker().then((engine) => {
@@ -157,7 +161,10 @@ loadAdblocker().then((engine) => {
 
     // Answer to content-script with a list of nodes
     if (msg.action === 'getCosmeticsFilters') {
-      const { active, blockedScripts, styles, scripts } = engine.getCosmeticsFilters(hostname);
+      const { active, blockedScripts, styles, scripts } = engine.getCosmeticsFilters(
+        hostname,
+        getDomain(hostname) || '',
+      );
       if (active === false) {
         return;
       }

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ export { default as CosmeticsInjection } from './src/cosmetics-injection';
 // Blocking
 export { default as FiltersEngine } from './src/engine/engine';
 export { default as ReverseIndex } from './src/engine/reverse-index';
-export { default as Request } from './src/request';
+export { default as Request, makeRequest } from './src/request';
 export { deserializeEngine } from './src/serialization';
 
 export { default as matchCosmeticFilter } from './src/matching/cosmetics';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6567,12 +6567,10 @@
       "dev": true
     },
     "tldts": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-3.1.2.tgz",
-      "integrity": "sha512-MbTi4o2oE7N3kqx+KC5hc6FM8jWY654lPXnwSjA7mw+J83DiW/tR8LBKEKqMvCvjwfbaZMEkIudyZ91c7dxEJg==",
-      "requires": {
-        "punycode": "^2.1.1"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-4.0.0.tgz",
+      "integrity": "sha512-0mduHx2iWhqQYPywIUHx5HpCYoBa3rIzq1KUTRVcu/McfBID/CvK557+MIFr+M1EubHNh1WnlMn8U8/VsLxfhw==",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -50,13 +50,13 @@
     "rollup": "^1.0.1",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-node-resolve": "^4.0.0",
+    "tldts": "^4.0.0",
     "ts-jest": "^23.10.5",
     "tslint": "^5.12.0",
     "typescript": "^3.2.2"
   },
   "dependencies": {
     "punycode": "^2.1.1",
-    "tldts": "^3.1.1",
     "tslib": "^1.9.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,7 +33,7 @@ export default [
   // Commonjs and ES module bundles (without third-party deps)
   {
     input: './build/index.js',
-    external: ['tldts', 'tslib', 'punycode'],
+    external: ['tslib', 'punycode'],
     output: [
       { file: pkg.module, format: 'es' },
       { file: pkg.main, format: 'cjs' },

--- a/src/engine/bucket/cosmetics.ts
+++ b/src/engine/bucket/cosmetics.ts
@@ -33,13 +33,13 @@ export default class CosmeticFilterBucket {
     this.size = this.hostnameIndex.size + this.genericRules.length;
   }
 
-  public getCosmeticsFilters(hostname: string) {
+  public getCosmeticsFilters(hostname: string, domain: string) {
     const disabledRules = new Set();
     const rules: CosmeticFilter[] = [];
 
     // Collect rules specifying a domain
     this.hostnameIndex.iterMatchingFilters(tokenizeHostnames(hostname), (rule: CosmeticFilter) => {
-      if (matchCosmeticFilter(rule, hostname)) {
+      if (matchCosmeticFilter(rule, hostname, domain)) {
         if (rule.isUnhide()) {
           disabledRules.add(rule.getSelector());
         } else {

--- a/src/matching/cosmetics.ts
+++ b/src/matching/cosmetics.ts
@@ -1,15 +1,10 @@
-import { getPublicSuffix } from 'tldts';
-
 import { CosmeticFilter } from '../parsing/cosmetic-filter';
 
 /* Checks that hostnamePattern matches at the end of the hostname.
  * Partial matches are allowed, but hostname should be a valid
  * subdomain of hostnamePattern.
  */
-function checkHostnamesPartialMatch(
-  hostname: string,
-  hostnamePattern: string,
-): boolean {
+function checkHostnamesPartialMatch(hostname: string, hostnamePattern: string): boolean {
   if (hostname.endsWith(hostnamePattern)) {
     const patternIndex = hostname.length - hostnamePattern.length;
     if (patternIndex === 0 || hostname[patternIndex - 1] === '.') {
@@ -28,23 +23,13 @@ function checkHostnamesPartialMatch(
  */
 function matchHostname(
   hostname: string,
+  hostnameWithoutPublicSuffix: string | null,
   hostnamePattern: string,
 ): boolean {
   if (hostnamePattern.endsWith('.*')) {
-    // Match entity:
-    const entity = hostnamePattern.slice(0, -2);
-
-    // Ignore TLDs suffix
-    const publicSuffix = getPublicSuffix(hostname);
-    if (publicSuffix === null) {
-      return false;
-    }
-
-    const hostnameWithoutSuffix = hostname.substr(0, hostname.length - publicSuffix.length - 1);
-
-    if (hostnameWithoutSuffix.length > 0) {
-      // Check if we have a match
-      return checkHostnamesPartialMatch(hostnameWithoutSuffix, entity);
+    // Check if we have an entity match
+    if (hostnameWithoutPublicSuffix !== null) {
+      return checkHostnamesPartialMatch(hostnameWithoutPublicSuffix, hostnamePattern.slice(0, -2));
     }
 
     return false;
@@ -53,7 +38,31 @@ function matchHostname(
   return checkHostnamesPartialMatch(hostname, hostnamePattern);
 }
 
-export default function matchCosmeticFilter(filter: CosmeticFilter, hostname: string): boolean {
+/**
+ * Given a hostname and its domain, return the hostname without the public
+ * suffix. We know that the domain, with one less label on the left, will be a
+ * the public suffix; and from there we know which trailing portion of
+ * `hostname` we should remove.
+ */
+export function getHostnameWithoutPublicSuffix(hostname: string, domain: string): string | null {
+  let hostnameWithoutPublicSuffix: string | null = null;
+
+  const indexOfDot = domain.indexOf('.');
+  if (indexOfDot !== -1) {
+    const publicSuffix = domain.slice(indexOfDot + 1);
+    hostnameWithoutPublicSuffix = hostname.slice(0, -publicSuffix.length - 1);
+  }
+
+  return hostnameWithoutPublicSuffix;
+}
+
+export default function matchCosmeticFilter(
+  filter: CosmeticFilter,
+  hostname: string,
+  domain: string,
+): boolean {
+  const hostnameWithoutPublicSuffix = getHostnameWithoutPublicSuffix(hostname, domain);
+
   // Check hostnames
   if (filter.hasHostnames()) {
     if (hostname) {
@@ -62,7 +71,10 @@ export default function matchCosmeticFilter(filter: CosmeticFilter, hostname: st
       // Check for exceptions
       for (let i = 0; i < hostnames.length; i += 1) {
         const filterHostname = hostnames[i];
-        if (filterHostname[0] === '~' && matchHostname(hostname, filterHostname.slice(1))) {
+        if (
+          filterHostname[0] === '~' &&
+          matchHostname(hostname, hostnameWithoutPublicSuffix, filterHostname.slice(1))
+        ) {
           return false;
         }
       }
@@ -70,7 +82,10 @@ export default function matchCosmeticFilter(filter: CosmeticFilter, hostname: st
       // Check for positive matches
       for (let i = 0; i < hostnames.length; i += 1) {
         const filterHostname = hostnames[i];
-        if (filterHostname[0] !== '~' && matchHostname(hostname, filterHostname)) {
+        if (
+          filterHostname[0] !== '~' &&
+          matchHostname(hostname, hostnameWithoutPublicSuffix, filterHostname)
+        ) {
           return true;
         }
       }


### PR DESCRIPTION
* Adblocker does not include tldts by default anymore
* API now expect either already constructed Request as argument of both
  hostname and domain when needed (e.g.: getCosmeticsFilters)
* A makeRequest helper is provided to construct Request objects
* [BREAKING] engine.match expects a `Request` as argument
* [BREAKING] engine.matchAll expects a `Request` as argument
* [BREAKING] engine.getCSPDirectives expects a `Request` as argument
* [BREAKING] engine.getCosmeticsFilter expects a new `domain` argument
* [BREAKING] `Request`'s constructor does not apply default value anymore and expects all arguments to be provided and initialized. You can now use `makeRequest` to reproduce the previous behavior of `new Request`.

This will allow two things:
1. The bundle is much smaller
2. This does not impose any particular URL parsing library upon the user of the adblocker (which will allow us to use different implementations on different platforms, for efficiency purposes).

@zhonghao-cliqz @chrmod 