### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released yet*
 
+## 0.5.0
+
+*2019-01-08*
+
   * Remove tldts dependency and allow to plug any implementation instead [#81](https://github.com/cliqz-oss/adblocker/pull/81)
     * Adblocker does not include tldts by default anymore
     * APIs now expect either already constructed Request as arguments of both

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library is the building block technology used to power Cliqz and Ghostery's
 
 The library provides the low-level implementation to fetch, parse and match filters; which makes it possible to manipulate the lists at a high level.
 
-## Developement
+## Development
 
 Install dependencies:
 ```sh
@@ -22,9 +22,7 @@ $ npm install
 
 Build:
 ```sh
-$ npm run build
-$ npm run bundle
-$ npm run bundle
+$ npm pack
 ```
 
 Test:
@@ -40,9 +38,9 @@ To publish a new version:
 
 1. Update `version` in [package.json](./package.json)
 2. Update [CHANGELOG.md](./CHANGELOG.md)
-3. New commit on local `master` branch (e.g.: `Release v0.1.x`)
-4. Add new tag `git tag -f -a vX.Y.Z -m "vX.Y.Z"`
-5. Push release commit + tag `git push upstream master --tags`
+3. New commit on local `master` branch (e.g.: `Release vx.y.z`)
+5. Make release PR with your commit
+6. Merge and create new Release on GitHub
 6. Travis takes care of the rest!
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This release contains many fixes as well as a few (small) breaking changes.

* Remove tldts dependency and allow to plug any implementation instead [#81](https://github.com/cliqz-oss/adblocker/pull/81)
  * Adblocker does not include tldts by default anymore
  * APIs now expect either already constructed Request as arguments of both
    hostname and domain when needed (e.g.: getCosmeticsFilters)
  * A makeRequest helper is provided to construct Request objects
  * [BREAKING] engine.match expects a `Request` as argument
  * [BREAKING] engine.matchAll expects a `Request` as argument
  * [BREAKING] engine.getCSPDirectives expects a `Request` as argument
  * [BREAKING] engine.getCosmeticsFilter expects a new `domain` argument
  * [BREAKING] `Request`'s constructor does not apply default value
    anymore and expects all arguments to be provided and initialized. You
    can now use `makeRequest` to reproduce the previous behavior of `new
    Request`.
* Fix cosmetics injection [#79](https://github.com/cliqz-oss/adblocker/pull/79)
  * Ignore cosmetic filters with extended syntax
  * Ignore invalid cosmetic filters (using strict validation)
  * Make use of tabs.insertCSS to inject style from background
* Update dependencies [#78](https://github.com/cliqz-oss/adblocker/pull/78)
* Harden typescript + simplify cosmetic injection [#71](https://github.com/cliqz-oss/adblocker/pull/71)
* Add support for Ghostery rules [#73](https://github.com/cliqz-oss/adblocker/pull/73)
  * Add support for `bug` filter attribute
  * Exceptions can now match filters with `bug` option
  * Simplify and speed-up serialization for network filters
  * Fix hostname anchor matching by preventing infix match in some corner case

