### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released yet*
 
+## 0.5.1
+
+* 2019-01-09*
+
   * Fix maximum number of selectors in stylesheet limitation on Chrome [#83](https://github.com/cliqz-oss/adblocker/pull/83)
 
 ## 0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "ES6",
     "outDir": "build",
     "newLine": "lf",
+    "esModuleInterop": true,
     "removeComments": true,
     "moduleResolution": "Node",
     "removeComments": true,


### PR DESCRIPTION
Quick fix release:

  * Fix maximum number of selectors in stylesheet limitation on Chrome [#83](https://github.com/cliqz-oss/adblocker/pull/83)
