### PR TITLE
Implement support for :style cosmetic filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 *not released yet*
 
+  * Implement support for :style cosmetic filters [#86](https://github.com/cliqz-oss/adblocker/pull/86)
+    * [BREAKING] `getCosmeticsFilters` will now return CSS as a single string
+      (stylesheet) instead of a list of selectors. This simplifies the usage and
+      allows to directly inject this into the page using the method of your
+      choice: through content scripts or tabs.injectCSS API.
+
 ## 0.5.1
 
 * 2019-01-09*

--- a/example/background.ts
+++ b/example/background.ts
@@ -174,7 +174,7 @@ loadAdblocker().then((engine) => {
         chrome.tabs.insertCSS(
           sender.tab.id,
           {
-            code: adblocker.createStylesheet(styles),
+            code: styles,
             cssOrigin: 'user',
             frameId: sender.frameId,
             matchAboutBlank: true,

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,5 @@
 // Cosmetic injection
-export { default as CosmeticsInjection } from './src/cosmetics-injection';
-export { createStylesheet } from './src/content/injection';
+export { default as injectCosmetics, IMessageFromBackground } from './src/cosmetics-injection';
 
 // Blocking
 export { default as FiltersEngine } from './src/engine/engine';

--- a/src/content/injection.ts
+++ b/src/content/injection.ts
@@ -96,13 +96,11 @@ export function bundle(fn: (...args: any[]) => void, deps: Array<(...args: any[]
  * in the page. This also takes care to no create rules with too many selectors
  * for Chrome, see: https://crbug.com/804179
  */
-export function createStylesheet(rules: string[]): string {
+export function createStylesheet(rules: string[], style: string): string {
   const maximumNumberOfSelectors = 1024;
   const parts: string[] = [];
   for (let i = 0; i < rules.length; i += maximumNumberOfSelectors) {
-    parts.push(
-      `${rules.slice(i, i + maximumNumberOfSelectors).join(',')} { display: none!important; }`,
-    );
+    parts.push(`${rules.slice(i, i + maximumNumberOfSelectors).join(',')} { ${style} }`);
   }
   return parts.join('\n');
 }

--- a/src/cosmetics-injection.ts
+++ b/src/cosmetics-injection.ts
@@ -1,11 +1,11 @@
 import injectCircumvention from './content/circumvention';
-import { blockScript, createStylesheet, injectCSSRule, injectScript } from './content/injection';
+import { blockScript, injectCSSRule, injectScript } from './content/injection';
 
 export interface IMessageFromBackground {
   active: boolean;
   scripts: string[];
   blockedScripts: string[];
-  styles: string[];
+  styles: string;
 }
 
 /**
@@ -50,7 +50,7 @@ export default function injectCosmetics(
 
       // Inject CSS
       if (styles && styles.length > 0) {
-        injectCSSRule(createStylesheet(styles), window.document);
+        injectCSSRule(styles, window.document);
       }
     },
   );

--- a/src/engine/bucket/cosmetics.ts
+++ b/src/engine/bucket/cosmetics.ts
@@ -33,7 +33,7 @@ export default class CosmeticFilterBucket {
     this.size = this.hostnameIndex.size + this.genericRules.length;
   }
 
-  public getCosmeticsFilters(hostname: string, domain: string) {
+  public getCosmeticsFilters(hostname: string, domain: string): CosmeticFilter[] {
     const disabledRules = new Set();
     const rules: CosmeticFilter[] = [];
 

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -145,6 +145,7 @@ function serializeCosmeticFilter(filter: CosmeticFilter, buffer: StaticDataView)
   buffer.pushUint32(filter.getId());
   buffer.pushUint8(filter.mask);
   buffer.pushUTF8(filter.selector);
+  buffer.pushASCII(filter.style);
 }
 
 /**
@@ -158,6 +159,7 @@ function deserializeCosmeticFilter(buffer: StaticDataView): CosmeticFilter {
     id: buffer.getUint32(),
     mask: buffer.getUint8(),
     selector: buffer.getUTF8(),
+    style: buffer.getASCII(),
   });
 }
 

--- a/test/injection.test.ts
+++ b/test/injection.test.ts
@@ -14,7 +14,7 @@ function testInjectCSS() {
       active: true,
       blockedScripts: [],
       scripts: [],
-      styles: [],
+      styles: '',
     }),
   );
 

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -697,6 +697,7 @@ function cosmetic(filter: string, expected: any) {
       // Attributes
       hostnames: parsed.getHostnames(),
       selector: parsed.getSelector(),
+      style: parsed.style,
 
       // Options
       isScriptBlock: parsed.isScriptBlock(),
@@ -713,6 +714,7 @@ const DEFAULT_COSMETIC_FILTER = {
   // Attributes
   hostnames: [],
   selector: '',
+  style: undefined,
 
   // Options
   isScriptBlock: false,
@@ -776,7 +778,7 @@ describe('Cosmetic filters', () => {
     });
   });
 
-  describe('parses script inject', () => {
+  it('parses script inject', () => {
     cosmetic('##script:inject(script.js, argument)', {
       ...DEFAULT_COSMETIC_FILTER,
       isScriptInject: true,
@@ -786,6 +788,27 @@ describe('Cosmetic filters', () => {
       ...DEFAULT_COSMETIC_FILTER,
       isScriptInject: true,
       selector: 'script.js, arg1, arg2, arg3',
+    });
+  });
+
+  it('parses :style', () => {
+    cosmetic('###foo :style(display: none)', {
+      ...DEFAULT_COSMETIC_FILTER,
+      selector: '#foo ',
+      style: 'display: none',
+    });
+
+    cosmetic('###foo > bar >baz:style(display: none)', {
+      ...DEFAULT_COSMETIC_FILTER,
+      selector: '#foo > bar >baz',
+      style: 'display: none',
+    });
+
+    cosmetic('foo.com,bar.de###foo > bar >baz:style(display: none)', {
+      ...DEFAULT_COSMETIC_FILTER,
+      hostnames: ['foo.com', 'bar.de'],
+      selector: '#foo > bar >baz',
+      style: 'display: none',
     });
   });
 });


### PR DESCRIPTION
Filters of the form `domains##selector:style(custom style)` can be used to apply a custom style to elements of the DOM (instead of hiding). This is needed to defuse some anti-adblocking mechanisms.

Changelog:
* Implement support for :style cosmetic filters [#86](https://github.com/cliqz-oss/adblocker/pull/86)
  * [BREAKING] `getCosmeticsFilters` will now return CSS as a single string
    (stylesheet) instead of a list of selectors. This simplifies the usage and
    allows to directly inject this into the page using the method of your
    choice: through content scripts or tabs.injectCSS API.