### PR TITLE
Make sure getId() always returns the same value for a given filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 *not released yet*
 
+## 0.6.2
+
+*2019-01-30*
+
+  * [bug] Make sure getId() always returns the same value for a given filter [#94](https://github.com/cliqz-oss/adblocker/pull/94)
+    * Previously the value of ID could change after some internal attribute
+      were changed during matching (in particular 'optDomains' and
+      'optNotDomains' would be sorted to allow more efficient matching which
+      would change the ID).
+
 ## 0.6.1
 
 *2019-01-28*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -124,13 +124,13 @@ export default class FilterEngine {
     // $csp=
     this.csp = new NetworkFilterBucket({ enableOptimizations: false });
     // @@filter
-    this.exceptions = new NetworkFilterBucket();
+    this.exceptions = new NetworkFilterBucket({ enableOptimizations });
     // $important
-    this.importants = new NetworkFilterBucket();
+    this.importants = new NetworkFilterBucket({ enableOptimizations });
     // $redirect
-    this.redirects = new NetworkFilterBucket();
+    this.redirects = new NetworkFilterBucket({ enableOptimizations });
     // All other filters
-    this.filters = new NetworkFilterBucket();
+    this.filters = new NetworkFilterBucket({ enableOptimizations });
     // Cosmetic filters
     this.cosmetics = new CosmeticFilterBucket();
 

--- a/src/engine/optimizer.ts
+++ b/src/engine/optimizer.ts
@@ -86,8 +86,8 @@ const OPTIMIZATIONS: IOptimization[] = [
 
       return new NetworkFilter({
         ...filters[0],
-        optDomains: domains.size > 0 ? new Uint32Array(domains) : undefined,
-        optNotDomains: notDomains.size > 0 ? new Uint32Array(notDomains) : undefined,
+        optDomains: domains.size > 0 ? new Uint32Array(domains).sort() : undefined,
+        optNotDomains: notDomains.size > 0 ? new Uint32Array(notDomains).sort() : undefined,
         rawLine:
           filters[0].rawLine !== undefined
             ? filters.map(({ rawLine }) => rawLine).join(' <+> ')

--- a/src/engine/reverse-index.ts
+++ b/src/engine/reverse-index.ts
@@ -69,6 +69,8 @@ class Bucket<T extends IFilter> {
   }
 }
 
+const EMPTY_BUCKET = Number.MAX_SAFE_INTEGER >>> 0;
+
 /**
  * The ReverseIndex is an accelerating data structure which allows finding a
  * subset of the filters given a list of token seen in a URL. It is the core of
@@ -244,7 +246,7 @@ export default class ReverseIndex<T extends IFilter> {
       const startOfBucket = view.getUint32();
 
       // We do not have any filters for this token
-      if (startOfBucket !== Number.MAX_SAFE_INTEGER) {
+      if (startOfBucket !== EMPTY_BUCKET) {
         view.setPos(startOfBucket);
 
         const numberOfFilters = view.getByte();
@@ -409,11 +411,10 @@ export default class ReverseIndex<T extends IFilter> {
 
     // We finished dumping all the filters so now starts the buckets index section
     const tokensLookupIndex = new Uint32Array(tokensLookupIndexSize);
-    const emptyBucket = Number.MAX_SAFE_INTEGER;
     for (let i = 0; i < tokensLookupIndexSize; i += 1) {
       const filtersForMask = prefixes[i];
       if (filtersForMask.length === 0) {
-        tokensLookupIndex[mask] = emptyBucket;
+        tokensLookupIndex[mask] = EMPTY_BUCKET;
       } else {
         tokensLookupIndex[i] = buffer.getPos();
         buffer.pushByte(filtersForMask.length);
@@ -457,7 +458,7 @@ export default class ReverseIndex<T extends IFilter> {
       const startOfBucket = view.getUint32();
 
       // We do not have any filters for this token
-      if (startOfBucket === Number.MAX_SAFE_INTEGER) {
+      if (startOfBucket === EMPTY_BUCKET) {
         return true;
       }
 

--- a/src/filters/cosmetic.ts
+++ b/src/filters/cosmetic.ts
@@ -275,6 +275,8 @@ export default class CosmeticFilter implements IFilter {
     }
 
     // We should not have unhide without any hostname
+    // NOTE: it does not make sense either to only have a negated domain or
+    // entity (e.g.: ~domain.com or ~entity.*), these are thus ignored.
     if (getBit(mask, COSMETICS_MASK.unhide) && hostnames === undefined && entities === undefined) {
       return null;
     }
@@ -615,6 +617,10 @@ export default class CosmeticFilter implements IFilter {
   public getTokens(): Uint32Array[] {
     const tokens: Uint32Array[] = [];
 
+    // Note, we do not need to use negated domains or entities as tokens here
+    // since they will by definition not match on their own, unless accompanied
+    // by a domain or entity.
+
     if (this.hostnames !== undefined) {
       for (let i = 0; i < this.hostnames.length; i += 1) {
         tokens.push(new Uint32Array([this.hostnames[i]]));
@@ -624,18 +630,6 @@ export default class CosmeticFilter implements IFilter {
     if (this.entities !== undefined) {
       for (let i = 0; i < this.entities.length; i += 1) {
         tokens.push(new Uint32Array([this.entities[i]]));
-      }
-    }
-
-    if (this.notEntities !== undefined) {
-      for (let i = 0; i < this.notEntities.length; i += 1) {
-        tokens.push(new Uint32Array([this.notEntities[i]]));
-      }
-    }
-
-    if (this.notHostnames !== undefined) {
-      for (let i = 0; i < this.notHostnames.length; i += 1) {
-        tokens.push(new Uint32Array([this.notHostnames[i]]));
       }
     }
 
@@ -683,10 +677,6 @@ export default class CosmeticFilter implements IFilter {
 
   public getSelector(): string {
     return this.selector;
-  }
-
-  public hasHostnames(): boolean {
-    return this.hostnames !== undefined;
   }
 
   public isUnhide(): boolean {

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -386,10 +386,14 @@ $csp=baz,domain=bar.com
     // - Engine with *no filter* optimizations *disabled*
     // - Engine with *all filters* optimizations *enabled*
     // - Engine with *all filters* optimizations *disabled*
-    // const engineEmptyOptimized = createEngine('', true);
-    // const engineEmpty = createEngine('', false);
-    const engineFullOptimized = createEngine(allRequestFilters, true);
-    const engineFull = createEngine(allRequestFilters, false);
+    const engineFullOptimized = Engine.parse(allRequestFilters, {
+      debug: true,
+      enableOptimizations: true,
+    });
+    const engineFull = Engine.parse(allRequestFilters, {
+      debug: true,
+      enableOptimizations: false,
+    });
 
     // For each request, make sure that we get the correct match in 4 different
     // setups:
@@ -524,8 +528,31 @@ $csp=baz,domain=bar.com
       ).toEqual('.selector ,.selector1  { foo }\n\n.selector  { bar }');
     });
 
-    // TODO - add more coverage here!
     [
+      // Negated entity on its own is ignored
+      {
+        hostname: 'google.com',
+        matches: ['##.adwords'],
+        misMatches: ['~google.*#@#.adwords'],
+      },
+      // Negated entity on its own is ignored
+      {
+        hostname: 'domain.com',
+        matches: ['##.adwords'],
+        misMatches: ['~google.*#@#.adwords'],
+      },
+      // Negated domain on its own is ignored
+      {
+        hostname: 'google.com',
+        matches: ['##.adwords'],
+        misMatches: ['~google.com#@#.adwords'],
+      },
+      // Negated domain on its own is ignored
+      {
+        hostname: 'google.de',
+        matches: ['##.adwords'],
+        misMatches: ['~google.com#@#.adwords'],
+      },
       // Exception cancels generic rule
       {
         hostname: 'google.com',

--- a/test/matching.test.ts
+++ b/test/matching.test.ts
@@ -195,6 +195,7 @@ describe('#NetworkFilter.match', () => {
 
     // No fuzzy signature, matches every URL?
     expect(f`+$fuzzy`).toMatchRequest({ url: 'http://bar.foo.baz' });
+    expect(f`$fuzzy`).toMatchRequest({ url: 'http://bar.foo.baz' });
   });
 
   it('||pattern', () => {
@@ -216,7 +217,11 @@ describe('#NetworkFilter.match', () => {
   });
 
   it('||pattern$fuzzy', () => {
-    expect(f`||bar.foo/baz$fuzzy`).toMatchRequest({ url: 'http://bar.foo/baz' });
+    const filter = f`||bar.foo/baz$fuzzy`;
+    expect(filter).toMatchRequest({ url: 'http://bar.foo/baz' });
+    // Same result when fuzzy signature is cached
+    expect(filter).toMatchRequest({ url: 'http://bar.foo/baz' });
+
     expect(f`||bar.foo/baz$fuzzy`).toMatchRequest({ url: 'http://bar.foo/id/baz' });
     expect(f`||bar.foo/baz$fuzzy`).toMatchRequest({ url: 'http://bar.foo?id=42&baz=1' });
     expect(f`||foo.com/id bar$fuzzy`).toMatchRequest({ url: 'http://foo.com?bar&id=42' });
@@ -350,6 +355,13 @@ describe('#NetworkFilter.match', () => {
 });
 
 describe('#CosmeticFilter.match', () => {
+  it('does not match with hostname constraint but none provided', () => {
+    expect(f`domain.com##.selector`).not.toMatchHostname('');
+    expect(f`domain.*##.selector`).not.toMatchHostname('');
+    expect(f`~domain.*##.selector`).not.toMatchHostname('');
+    expect(f`~domain.com##.selector`).not.toMatchHostname('');
+  });
+
   it('genercic filter', () => {
     expect(f`##.selector`).toMatchHostname('foo.com');
   });

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -1,6 +1,18 @@
+import { loadResources } from './utils';
+
+import StaticDataView from '../src/data-view';
 import Resources from '../src/resources';
 
 describe('#Resources', () => {
+  describe('#serialize', () => {
+    const resources = Resources.parse(loadResources(), { checksum: 'checksum' });
+    expect(resources.checksum).toEqual('checksum');
+    const buffer = new StaticDataView(2000000);
+    resources.serialize(buffer);
+    buffer.seekZero();
+    expect(Resources.deserialize(buffer)).toEqual(resources);
+  });
+
   describe('#parse', () => {
     it('parses empty resources', () => {
       const resources = Resources.parse('', { checksum: 'checksum' });

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -13,10 +13,20 @@ describe('Serialization', () => {
   describe('filters', () => {
     const buffer = new StaticDataView(1000000);
     const checkFilterSerialization = (Filter: any, filter: IFilter) => {
+      // Keep track of original ID to make sure it's preserved after lazy
+      // attributes are set and filter is serialized/deserialized.
+      const originalId = filter.getId();
+
+      // Serialize filter
       buffer.seekZero();
       filter.serialize(buffer);
       buffer.seekZero();
-      expect(Filter.deserialize(buffer)).toEqual(filter);
+
+      // Reload filter
+      const deserialized = Filter.deserialize(buffer);
+      expect(deserialized.id).toBeUndefined();
+      expect(deserialized.getId()).toBe(originalId);
+      expect(deserialized).toEqual(filter);
     };
 
     it('cosmetic', () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -9,14 +9,19 @@ export function loadAllLists() {
   return [
     'assets/easylist-downloads.adblockplus.org/antiadblockfilters.txt',
     'assets/easylist.to/easylist/easylist.txt',
+    'assets/easylist.to/easylist/easyprivacy.txt',
     'assets/easylist.to/easylistgermany/easylistgermany.txt',
     'assets/raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt',
     'assets/raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt',
     'assets/raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt',
     'assets/raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt',
-  ].map(readAsset).join('\n');
+  ]
+    .map(readAsset)
+    .join('\n');
 }
 
 export function loadResources() {
-  return readAsset('assets/raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resources.txt');
+  return readAsset(
+    'assets/raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resources.txt',
+  );
 }


### PR DESCRIPTION
Previously the value of ID could change after some internal attribute were changed during matching (in particular 'optDomains' and 'optNotDomains' would be sorted to allow more efficient matching which would change the ID).