### PR TITLE
Release v0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 *not released yet*
 
+## 0.6.9
+
+*2019-02-15*
+
+  * Fix stack overflow error on Edge [#105](https://github.com/cliqz-oss/adblocker/pull/105)
+  * Update and clean-up travis config [#104](https://github.com/cliqz-oss/adblocker/pull/104)
+  * Add rawType attribute to `Request` class [#102](https://github.com/cliqz-oss/adblocker/pull/104)
+
 ## 0.6.8
 
 *2019-02-08*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -10,7 +10,7 @@ import NetworkFilterBucket from './bucket/network';
 
 import { createStylesheet } from '../content/injection';
 
-export const ENGINE_VERSION = 21;
+export const ENGINE_VERSION = 22;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
  * Fix stack overflow error on Edge [#105](https://github.com/cliqz-oss/adblocker/pull/105)
  * Update and clean-up travis config [#104](https://github.com/cliqz-oss/adblocker/pull/104)
  * Add rawType attribute to `Request` class [#102](https://github.com/cliqz-oss/adblocker/pull/104)