### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 *not released yet*
 
+## 0.7.0
+
+*2019-03-08*
+
+  * Introduce Config object + remove lists abstractions [#111](https://github.com/cliqz-oss/adblocker/pull/111)
+  * Remove bench deps + fix matching by using initiator as sourceUrl [#109](https://github.com/cliqz-oss/adblocker/pull/108)
+  * Update benchmarks [#108](https://github.com/cliqz-oss/adblocker/pull/108)
+    * comparison: include request processing for each benchmark
+    * Use latest uBlock Origin with WebAssembly enabled
+    * Update results from benchmarks and clean-up
+    * Add benchmark for regex-based hostname extraction
+
 ## 0.6.9
 
 *2019-02-15*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.6.9",
+  "version": "0.7.0",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Introduce Config object + remove lists abstractions [#111](https://github.com/cliqz-oss/adblocker/pull/111)
* Remove bench deps + fix matching by using initiator as sourceUrl [#109](https://github.com/cliqz-oss/adblocker/pull/108)
* Update benchmarks [#108](https://github.com/cliqz-oss/adblocker/pull/108)
  * comparison: include request processing for each benchmark
  * Use latest uBlock Origin with WebAssembly enabled
  * Update results from benchmarks and clean-up
  * Add benchmark for regex-based hostname extraction

