### PR TITLE
Implement generichide option + fix generic cosmetic matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 *not released yet*
 
+  * Implement generichide option + fix generic cosmetic matching [#114](https://github.com/cliqz-oss/adblocker/pull/114)
+    * [BREAKING] Change arguments of FiltersEngine.getCosmeticsFilters
+      getCosmeticsFilters({ url, hostname, domain }) is now expected
+      instead of getCosmeticsFilters(hostname, domain). This allows to
+      apply $generichide options which can match on arbitrary parts of the
+      main_frame URL (not only hostname).
+    * Add support for $generichide option in network filters
+    * Fix matching of generic cosmetics when only negation was specified
+
 ## 0.7.0
 
 *2019-03-08*

--- a/src/filters/cosmetic.ts
+++ b/src/filters/cosmetic.ts
@@ -538,15 +538,6 @@ export default class CosmeticFilter implements IFilter {
     return filter;
   }
 
-  public hasHostnameConstraint(): boolean {
-    return (
-      this.hostnames !== undefined ||
-      this.entities !== undefined ||
-      this.notEntities !== undefined ||
-      this.notHostnames !== undefined
-    );
-  }
-
   public match(hostname: string, domain: string): boolean {
     // No `hostname` available but this filter has some constraints on hostname.
     if (
@@ -657,6 +648,15 @@ export default class CosmeticFilter implements IFilter {
     return undefined;
   }
 
+  public hasHostnameConstraint(): boolean {
+    return (
+      this.hostnames !== undefined ||
+      this.entities !== undefined ||
+      this.notEntities !== undefined ||
+      this.notHostnames !== undefined
+    );
+  }
+
   public getId(): number {
     if (this.id === undefined) {
       this.id = computeFilterId(
@@ -689,5 +689,15 @@ export default class CosmeticFilter implements IFilter {
 
   public isScriptBlock(): boolean {
     return getBit(this.mask, COSMETICS_MASK.scriptBlock);
+  }
+
+  // A generic hide cosmetic filter is one that:
+  //
+  // * Do not have a domain specified. "Hide this element on all domains"
+  // * Have only domain exceptions specified. "Hide this element on all domains except example.com"
+  //
+  // For example: ~example.com##.ad  is a generic filter as well
+  public isGenericHide(): boolean {
+    return this.hostnames === undefined && this.entities === undefined;
   }
 }

--- a/src/filters/network.ts
+++ b/src/filters/network.ts
@@ -51,6 +51,7 @@ export const enum NETWORK_FILTER_MASK {
   isHostnameAnchor = 1 << 21,
   isException = 1 << 22,
   isCSP = 1 << 23,
+  isGenericHide = 1 << 24,
 }
 
 /**
@@ -340,6 +341,9 @@ export default class NetworkFilter implements IFilter {
             if (optionValue.length > 0) {
               csp = optionValue;
             }
+            break;
+          case 'generichide':
+            mask = setBit(mask, NETWORK_FILTER_MASK.isGenericHide);
             break;
           default: {
             // Handle content type options separatly
@@ -856,6 +860,10 @@ export default class NetworkFilter implements IFilter {
       options.push(`csp=${this.csp}`);
     }
 
+    if (this.isGenericHide()) {
+      options.push('generichide');
+    }
+
     if (this.hasBug()) {
       options.push(`bug=${this.bug}`);
     }
@@ -1071,6 +1079,10 @@ export default class NetworkFilter implements IFilter {
 
   public isCSP() {
     return getBit(this.mask, NETWORK_FILTER_MASK.isCSP);
+  }
+
+  public isGenericHide() {
+    return getBit(this.mask, NETWORK_FILTER_MASK.isGenericHide);
   }
 
   public hasBug() {

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -112,10 +112,7 @@ export function parseFilters(
       } else if (filterType === FilterType.COSMETIC && config.loadCosmeticFilters) {
         const filter = CosmeticFilter.parse(line, config.debug);
         if (filter !== null) {
-          if (
-            config.loadGenericCosmeticsFilters === true ||
-            filter.hasHostnameConstraint() === false
-          ) {
+          if (config.loadGenericCosmeticsFilters === true || filter.isGenericHide() === false) {
             cosmeticFilters.push(filter);
           }
         }

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -29,6 +29,7 @@ function network(filter: string, expected: any) {
       // Filter type
       isCSP: parsed.isCSP(),
       isException: parsed.isException(),
+      isGenericHide: parsed.isGenericHide(),
       isHostnameAnchor: parsed.isHostnameAnchor(),
       isLeftAnchor: parsed.isLeftAnchor(),
       isPlain: parsed.isPlain(),
@@ -74,6 +75,7 @@ const DEFAULT_NETWORK_FILTER = {
   // Filter type
   isCSP: false,
   isException: false,
+  isGenericHide: false,
   isHostnameAnchor: false,
   isLeftAnchor: false,
   isPlain: false,
@@ -710,20 +712,19 @@ describe('Network filters', () => {
       });
     });
 
+    it('generichide', () => {
+      network('||foo.com^$generichide', { isGenericHide: true });
+      network('@@||foo.com^$generichide', { isGenericHide: true, isException: true });
+    });
+
     describe('un-supported options', () => {
-      [
-        'badfilter',
-        'genericblock',
-        'generichide',
-        'inline-script',
-        'popunder',
-        'popup',
-        'woot',
-      ].forEach((unsupportedOption) => {
-        it(unsupportedOption, () => {
-          network(`||foo.com$${unsupportedOption}`, null);
-        });
-      });
+      ['badfilter', 'genericblock', 'inline-script', 'popunder', 'popup', 'woot'].forEach(
+        (unsupportedOption) => {
+          it(unsupportedOption, () => {
+            network(`||foo.com$${unsupportedOption}`, null);
+          });
+        },
+      );
     });
 
     const allOptions = (value: boolean) => ({


### PR DESCRIPTION
* [BREAKING] Change arguments of FiltersEngine.getCosmeticsFilters
    getCosmeticsFilters({ url, hostname, domain }) is now expected
    instead of getCosmeticsFilters(hostname, domain). This allows to
    apply $generichide options which can match on arbitrary parts of the
    main_frame URL (not only hostname).
* Add support for $generichide option in network filters
* Fix matching of generic cosmetics when only negation was specified

Closes https://cliqztix.atlassian.net/browse/EX-4220