### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 *not released yet*
 
+## 0.8.0
+
+*2019-03-26*
+
+  * Support for cyrillic characters [#115](https://github.com/cliqz-oss/adblocker/pull/115)
   * Implement generichide option + fix generic cosmetic matching [#114](https://github.com/cliqz-oss/adblocker/pull/114)
     * [BREAKING] Change arguments of FiltersEngine.getCosmeticsFilters
       getCosmeticsFilters({ url, hostname, domain }) is now expected
@@ -12,7 +17,6 @@
       main_frame URL (not only hostname).
     * Add support for $generichide option in network filters
     * Fix matching of generic cosmetics when only negation was specified
-  * Support for cyrillic characters [#115](https://github.com/cliqz-oss/adblocker/pull/115)
 
 ## 0.7.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3410,9 +3410,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",


### PR DESCRIPTION
* Support for cyrillic characters [#115](https://github.com/cliqz-oss/adblocker/pull/115)
* Implement generichide option + fix generic cosmetic matching [#114](https://github.com/cliqz-oss/adblocker/pull/114)
  * [BREAKING] Change arguments of FiltersEngine.getCosmeticsFilters
    getCosmeticsFilters({ url, hostname, domain }) is now expected
    instead of getCosmeticsFilters(hostname, domain). This allows to
    apply $generichide options which can match on arbitrary parts of the
    main_frame URL (not only hostname).
  * Add support for $generichide option in network filters
  * Fix matching of generic cosmetics when only negation was specified

