### PR TITLE
pprint stylesheets

### DIFF
--- a/src/content/injection.ts
+++ b/src/content/injection.ts
@@ -89,7 +89,7 @@ export function createStylesheet(rules: string[], style: string): string {
   const maximumNumberOfSelectors = 1024;
   const parts: string[] = [];
   for (let i = 0; i < rules.length; i += maximumNumberOfSelectors) {
-    parts.push(`${rules.slice(i, i + maximumNumberOfSelectors).join(',')} { ${style} }`);
+    parts.push(`${rules.slice(i, i + maximumNumberOfSelectors).join(',\n')} { ${style} }`);
   }
   return parts.join('\n');
 }

--- a/test/engine.test.ts
+++ b/test/engine.test.ts
@@ -567,7 +567,7 @@ $csp=baz,domain=bar.com
 ##.selector1 :style(foo)`,
         ).getCosmeticsFilters({ domain: 'foo.com', hostname: 'foo.com', url: 'https://foo.com' })
           .styles,
-      ).toEqual('.selector ,.selector1  { foo }\n\n.selector  { bar }');
+      ).toEqual('.selector ,\n.selector1  { foo }\n\n.selector  { bar }');
     });
 
     [


### PR DESCRIPTION
Currently the stylesheets are one-liners. Adding a line-break makes reading them easier (especially while debugging).