### PR TITLE
Implement variable-length encoding in StaticDataView to save space

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ dist: xenial
 language: node_js
 
 node_js:
-  - 6
-  - 8
-  - 10
+  - lts/*
   - node
 
 notifications:

--- a/src/data-view.ts
+++ b/src/data-view.ts
@@ -3,6 +3,7 @@ import { decode, encode } from './punycode';
 export const EMPTY_UINT8_ARRAY = new Uint8Array(0);
 export const EMPTY_UINT32_ARRAY = new Uint32Array(0);
 
+// Check if current architecture is little endian
 const LITTLE_ENDIAN: boolean = new Int8Array(new Int16Array([1]).buffer)[0] === 1;
 
 /**
@@ -19,16 +20,47 @@ const LITTLE_ENDIAN: boolean = new Int8Array(new Int16Array([1]).buffer)[0] === 
  * deserializer you use `getX` functions to get back the values.
  */
 export default class StaticDataView {
+  /**
+   * Return number of bytes needed to serialize `str` ASCII string.
+   */
+  public static sizeOfASCII(str: string): number {
+    return StaticDataView.sizeOfLength(str.length) + str.length;
+  }
+
+  /**
+   * Return number of bytes needed to serialize `str` UTF8 string.
+   */
+  public static sizeOfUTF8(str: string): number {
+    const encoded = encode(str);
+    return StaticDataView.sizeOfLength(encoded.length) + encoded.length;
+  }
+
+  /**
+   * Return number of bytes needed to serialize `array`.
+   */
+  public static sizeOfUint32Array(array: Uint32Array): number {
+    return array.byteLength + StaticDataView.sizeOfLength(array.length);
+  }
+
+  /**
+   * Create an empty (i.e.: size = 0) StaticDataView.
+   */
   public static empty(): StaticDataView {
     return StaticDataView.fromUint8Array(EMPTY_UINT8_ARRAY);
   }
 
-  public static fromUint32Array(array: Uint32Array): StaticDataView {
-    return new StaticDataView(0, new Uint8Array(array.buffer));
-  }
-
+  /**
+   * Instantiate a StaticDataView instance from `array` of type Uint8Array.
+   */
   public static fromUint8Array(array: Uint8Array): StaticDataView {
     return new StaticDataView(0, array);
+  }
+
+  /**
+   * Return number of bytes needed to serialize `length`.
+   */
+  private static sizeOfLength(length: number): number {
+    return length <= 127 ? 1 : 5;
   }
 
   public pos: number;
@@ -68,13 +100,11 @@ export default class StaticDataView {
   }
 
   /**
-   * Make sure that `this.pos` is aligned on a multiple of `alignement`.
+   * Make sure that `this.pos` is aligned on a multiple of 4.
    */
-  public align(alignement: number): void {
-    this.pos =
-      this.pos % alignement === 0
-        ? this.pos
-        : Math.floor(this.pos / alignement) * alignement + alignement;
+  public align4(): void {
+    // From: https://stackoverflow.com/a/2022194
+    this.pos = (this.pos + 3) & ~0x03;
   }
 
   public set(buffer: Uint8Array): void {
@@ -102,14 +132,24 @@ export default class StaticDataView {
     return this.getUint8();
   }
 
-  public pushBytes(bytes: Uint8Array): void {
-    this.pushUint32(bytes.byteLength);
+  public pushBytes(bytes: Uint8Array, align: boolean = false): void {
+    this.pushLength(bytes.length);
+
+    if (align === true) {
+      this.align4();
+    }
+
     this.buffer.set(bytes, this.pos);
     this.pos += bytes.byteLength;
   }
 
-  public getBytes(): Uint8Array {
-    const numberOfBytes = this.getUint32();
+  public getBytes(align: boolean = false): Uint8Array {
+    const numberOfBytes = this.getLength();
+
+    if (align === true) {
+      this.align4();
+    }
+
     const bytes = this.buffer.subarray(this.pos, this.pos + numberOfBytes);
     this.pos += numberOfBytes;
     return bytes;
@@ -122,7 +162,7 @@ export default class StaticDataView {
    */
   public getUint32ArrayView(desiredSize: number): Uint32Array {
     // Round this.pos to next multiple of 4 for alignement
-    this.align(4);
+    this.align4();
 
     // Short-cut when empty array
     if (desiredSize === 0) {
@@ -174,13 +214,7 @@ export default class StaticDataView {
   }
 
   public pushUint32Array(arr: Uint32Array): void {
-    const len: number = arr.length;
-    const length = len <= 127 ? len : 1 << 7;
-    this.pushUint8(length);
-    if (len > 127) {
-      this.pushUint16(len);
-    }
-
+    this.pushLength(arr.length);
     // TODO - use `set` to push the full buffer at once?
     for (let i = 0; i < arr.length; i += 1) {
       this.pushUint32(arr[i]);
@@ -188,8 +222,7 @@ export default class StaticDataView {
   }
 
   public getUint32Array(): Uint32Array {
-    const len = this.getUint8();
-    const length = len === 1 << 7 ? this.getUint16() : len;
+    const length = this.getLength();
     const arr = new Uint32Array(length);
     // TODO - use `subarray`?
     for (let i = 0; i < length; i += 1) {
@@ -200,7 +233,7 @@ export default class StaticDataView {
 
   public pushUTF8(raw: string): void {
     const str = encode(raw);
-    this.pushUint16(str.length);
+    this.pushLength(str.length);
 
     for (let i = 0; i < str.length; i += 1) {
       this.buffer[this.pos++] = str.charCodeAt(i);
@@ -208,7 +241,7 @@ export default class StaticDataView {
   }
 
   public getUTF8(): string {
-    const byteLength = this.getUint16();
+    const byteLength = this.getLength();
     this.pos += byteLength;
     return decode(
       String.fromCharCode.apply(
@@ -220,7 +253,7 @@ export default class StaticDataView {
   }
 
   public pushASCII(str: string): void {
-    this.pushUint16(str.length);
+    this.pushLength(str.length);
 
     for (let i = 0; i < str.length; i += 1) {
       this.buffer[this.pos++] = str.charCodeAt(i);
@@ -228,7 +261,7 @@ export default class StaticDataView {
   }
 
   public getASCII(): string {
-    const byteLength = this.getUint16();
+    const byteLength = this.getLength();
     this.pos += byteLength;
 
     // @ts-ignore
@@ -241,5 +274,20 @@ export default class StaticDataView {
         `StaticDataView too small: ${this.buffer.byteLength}, but required ${this.pos - 1} bytes`,
       );
     }
+  }
+
+  // Serialiez `length` with variable encoding to save space
+  private pushLength(length: number): void {
+    if (length <= 127) {
+      this.pushUint8(length);
+    } else {
+      this.pushUint8(128);
+      this.pushUint32(length);
+    }
+  }
+
+  private getLength(): number {
+    const lengthShort = this.getUint8();
+    return lengthShort === 128 ? this.getUint32() : lengthShort;
   }
 }

--- a/src/engine/reverse-index.ts
+++ b/src/engine/reverse-index.ts
@@ -127,11 +127,11 @@ export default class ReverseIndex<T extends IFilter> {
     // appear at any offset of `buffer`. But to be sure we can read back
     // Uint32Array directly from raw buffer, the alignement has to be a multiple
     // of 4. The same alignement is taken care of in `serialize`.
-    buffer.align(4);
-    const view = StaticDataView.fromUint8Array(buffer.getBytes());
+    const view = StaticDataView.fromUint8Array(buffer.getBytes(true /* align */));
 
     // Read Uint32Array views on top of byte array for fast access.
     view.setPos(tokensLookupIndexStart);
+
     const tokensLookupIndex = view.getUint32ArrayView(tokensLookupIndexSize);
     const bucketsIndex = view.getUint32ArrayView(bucketsIndexSize);
     view.seekZero();
@@ -297,8 +297,7 @@ export default class ReverseIndex<T extends IFilter> {
     buffer.pushUint32(this.bucketsIndex.length);
 
     // Aligmenent is crucial here, see comment in `deserialize` for more info.
-    buffer.align(4);
-    buffer.pushBytes(this.view.buffer);
+    buffer.pushBytes(this.view.buffer, true /* align */);
   }
 
   /**

--- a/src/filters/cosmetic.ts
+++ b/src/filters/cosmetic.ts
@@ -1,5 +1,5 @@
 import StaticDataView from '../data-view';
-import { encode, toASCII } from '../punycode';
+import { toASCII } from '../punycode';
 import { binLookup, fastStartsWithFrom, getBit, hasUnicode, setBit } from '../utils';
 import IFilter from './interface';
 
@@ -518,49 +518,37 @@ export default class CosmeticFilter implements IFilter {
     let estimate: number = 1 + 1; // mask (1 byte) + optional parts (1 byte)
 
     if (this.isUnicode()) {
-      estimate += encode(this.selector).length + 2;
+      estimate += StaticDataView.sizeOfUTF8(this.selector);
     } else {
-      estimate += this.selector.length + 2;
+      estimate += StaticDataView.sizeOfASCII(this.selector);
     }
 
     if (this.entities !== undefined) {
-      estimate += this.entities.length * 4 + 1;
-      if (this.entities.length > 127) {
-        estimate += 2;
-      }
+      estimate += StaticDataView.sizeOfUint32Array(this.entities);
     }
 
     if (this.hostnames !== undefined) {
-      estimate += this.hostnames.length * 4 + 1;
-      if (this.hostnames.length > 127) {
-        estimate += 2;
-      }
+      estimate += StaticDataView.sizeOfUint32Array(this.hostnames);
     }
 
     if (this.notHostnames !== undefined) {
-      estimate += this.notHostnames.length * 4 + 1;
-      if (this.notHostnames.length > 127) {
-        estimate += 2;
-      }
+      estimate += StaticDataView.sizeOfUint32Array(this.notHostnames);
     }
 
     if (this.notEntities !== undefined) {
-      estimate += this.notEntities.length * 4 + 1;
-      if (this.notEntities.length > 127) {
-        estimate += 2;
-      }
+      estimate += StaticDataView.sizeOfUint32Array(this.notEntities);
     }
 
     if (this.rawLine !== undefined) {
       if (this.isUnicode()) {
-        estimate += encode(this.rawLine).length + 2;
+        estimate += StaticDataView.sizeOfUTF8(this.rawLine);
       } else {
-        estimate += this.rawLine.length + 2;
+        estimate += StaticDataView.sizeOfASCII(this.rawLine);
       }
     }
 
     if (this.style !== undefined) {
-      estimate += this.style.length + 2;
+      estimate += StaticDataView.sizeOfASCII(this.style);
     }
 
     return estimate;

--- a/src/filters/network.ts
+++ b/src/filters/network.ts
@@ -1,5 +1,5 @@
 import StaticDataView from '../data-view';
-import { encode, toASCII } from '../punycode';
+import { toASCII } from '../punycode';
 import { RequestType } from '../request';
 import Request from '../request';
 import {
@@ -734,45 +734,39 @@ export default class NetworkFilter implements IFilter {
     let estimate: number = 4 + 1; // mask = 4 bytes // optional parts = 1 byte
 
     if (this.csp !== undefined) {
-      estimate += this.csp.length + 2;
+      estimate += StaticDataView.sizeOfASCII(this.csp);
     }
 
     if (this.filter !== undefined) {
       if (this.isUnicode()) {
-        estimate += encode(this.filter).length + 2;
+        estimate += StaticDataView.sizeOfUTF8(this.filter);
       } else {
-        estimate += this.filter.length + 2;
+        estimate += StaticDataView.sizeOfASCII(this.filter);
       }
     }
 
     if (this.hostname !== undefined) {
-      estimate += this.hostname.length + 2;
+      estimate += StaticDataView.sizeOfASCII(this.hostname);
     }
 
     if (this.optDomains !== undefined) {
-      estimate += this.optDomains.length * 4 + 1;
-      if (this.optDomains.length > 127) {
-        estimate += 2;
-      }
+      estimate += StaticDataView.sizeOfUint32Array(this.optDomains);
     }
 
     if (this.optNotDomains !== undefined) {
-      estimate += this.optNotDomains.length * 4 + 1;
-      if (this.optNotDomains.length > 127) {
-        estimate += 2;
-      }
+      estimate += StaticDataView.sizeOfUint32Array(this.optNotDomains);
     }
 
     if (this.rawLine !== undefined) {
       if (this.isUnicode()) {
-        estimate += encode(this.rawLine).length + 2;
+        estimate += StaticDataView.sizeOfUTF8(this.rawLine);
       } else {
-        estimate += this.rawLine.length + 2;
+        estimate += StaticDataView.sizeOfASCII(this.rawLine);
       }
     }
 
     if (this.redirect !== undefined) {
-      estimate += this.redirect.length + 2;
+      estimate += StaticDataView.sizeOfASCII(this.redirect);
     }
 
     return estimate;


### PR DESCRIPTION
- Implement more efficient encoding for length of strings/bytes/arrays in `StaticDataView` (Saving of ~4% of the total size)
- Fix issue with alignment of `Uint32Array` when serializing/deserializing (alignment should be done after persisting the size of the array, not before)
- Clean-up Node.js versions tested in Travis.