### PR TITLE
Introduce TokensBuffer to speed-up tokenization of filters and requests

### DIFF
--- a/bench/micro.js
+++ b/bench/micro.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-bitwise */
+
 const adblocker = require('../');
 const { createEngine } = require('./utils');
 
@@ -41,7 +43,7 @@ function benchParsingImpl(lists, { loadNetworkFilters, loadCosmeticFilters }) {
     dummy = (dummy + adblocker.parseFilters(lists[i], {
       loadNetworkFilters,
       loadCosmeticFilters,
-    }).networkFilters.length) % 100000;
+    }).networkFilters.length) >>> 0;
   }
 
   return dummy;
@@ -61,6 +63,26 @@ function benchNetworkFiltersParsing({ lists }) {
   });
 }
 
+function benchGetNetworkTokens({ networkFilters }) {
+  let dummy = 0;
+
+  for (let i = 0; i < networkFilters.length; i += 1) {
+    dummy = (dummy + networkFilters[i].getTokens().length) >>> 0;
+  }
+
+  return dummy;
+}
+
+function benchGetCosmeticTokens({ cosmeticFilters }) {
+  let dummy = 0;
+
+  for (let i = 0; i < cosmeticFilters.length; i += 1) {
+    dummy = (dummy + cosmeticFilters[i].getTokens().length) >>> 0;
+  }
+
+  return dummy;
+}
+
 module.exports = {
   benchCosmeticsFiltersParsing,
   benchEngineCreation,
@@ -69,4 +91,6 @@ module.exports = {
   benchNetworkFiltersParsing,
   benchStringHashing,
   benchStringTokenize,
+  benchGetNetworkTokens,
+  benchGetCosmeticTokens,
 };

--- a/bench/utils.js
+++ b/bench/utils.js
@@ -1,7 +1,7 @@
-const adblocker = require('../');
+const { FiltersEngine, parseFilters } = require('../');
 
 function createEngine(lists, resources, options = {}, serialize = false) {
-  const engine = adblocker.FiltersEngine.parse(
+  const engine = FiltersEngine.parse(
     lists.join('\n'),
     options,
   );
@@ -20,9 +20,9 @@ function getFiltersFromLists(lists) {
   const filters = [];
 
   for (let i = 0; i < lists.length; i += 1) {
-    const splitted = lists[i].split(/\n/g);
-    for (let j = 0; j < splitted.length; j += 1) {
-      filters.push(splitted[j]);
+    const split = lists[i].split(/\n/g);
+    for (let j = 0; j < split.length; j += 1) {
+      filters.push(split[j]);
     }
   }
 
@@ -34,4 +34,5 @@ module.exports = {
   createEngine,
   NANOSECS_PER_SEC,
   getFiltersFromLists,
+  parseFilters,
 };

--- a/src/tokens-buffer.ts
+++ b/src/tokens-buffer.ts
@@ -1,0 +1,32 @@
+/**
+ * Thin abstraction around a Uint32Array which allows to push tokens
+ * whithout caring for the offset. It is used as a way to avoid multiple
+ * allocations while calling tokenization (mostly beneficitial for
+ * `NetworkFilter.getTokens()`).
+ */
+export default class TokensBuffer {
+  public readonly size: number;
+  public pos: number;
+  private readonly buffer: Uint32Array;
+
+  constructor(size: number) {
+    this.size = size;
+    this.pos = 0;
+    this.buffer = new Uint32Array(size);
+  }
+
+  public seekZero(): void {
+    this.pos = 0;
+  }
+
+  public slice(): Uint32Array {
+    if (this.pos !== 0 && this.pos > this.buffer.length) {
+      throw new Error(`StaticDataView too small: ${this.buffer.length}, but required ${this.pos}`);
+    }
+    return this.buffer.slice(0, this.pos);
+  }
+
+  public push(token: number): void {
+    this.buffer[this.pos++] = token;
+  }
+}

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -8,7 +8,6 @@ import {
   hasUnicode,
   tokenize,
   tokenizeFilter,
-  tokenizeHostnames,
   updateResponseHeadersWithCSP,
 } from '../src/utils';
 import requests from './data/requests';
@@ -79,16 +78,6 @@ describe('Utils', () => {
     expect(tokenizeFilter('foo/bar baz', true, true)).toEqual(t(['bar']));
     expect(tokenizeFilter('foo/bar baz', false, true)).toEqual(t(['foo', 'bar']));
     expect(tokenizeFilter('foo////bar  baz', false, true)).toEqual(t(['foo', 'bar']));
-  });
-
-  it('#tokenizeHostnames', () => {
-    expect(tokenizeHostnames('')).toEqual(t([]));
-    expect(tokenizeHostnames('foo')).toEqual(t(['foo']));
-    expect(tokenizeHostnames('foo/bar')).toEqual(t(['foo', 'bar']));
-    expect(tokenizeHostnames('foo-barbaz/bar')).toEqual(t(['foo-barbaz', 'bar']));
-    expect(tokenizeHostnames('foo_barbaz/ba%r')).toEqual(t(['foo_barbaz', 'ba%r']));
-    expect(tokenizeHostnames('foo_barbaz/ba%r*')).toEqual(t(['foo_barbaz', 'ba%r']));
-    expect(tokenizeHostnames('foo_barbaz///ba%r*')).toEqual(t(['foo_barbaz', 'ba%r']));
   });
 
   it('#tokenize', () => {


### PR DESCRIPTION
* bench: add GREP option + getTokens micro-benchmarks
* Introduce TokensBuffer to speed-up tokenization of filters and requests

This results in a 25% speed-ups on `NetworkFilters.getTokens` which is one of the bottle-necks of `ReverseIndex.update`.