### PR TITLE
network: drop RegExp patterns

### DIFF
--- a/src/filters/network.ts
+++ b/src/filters/network.ts
@@ -410,6 +410,15 @@ export default class NetworkFilter implements IFilter {
       mask |= cptMaskPositive & cptMaskNegative;
     }
 
+    // Detect and drop Regexps
+    if (
+      filterIndexEnd - filterIndexStart >= 2 &&
+      line.charCodeAt(filterIndexStart) === 47 /* '/' */ &&
+      line.charCodeAt(filterIndexEnd - 1) === 47 /* '/' */
+    ) {
+      return null;
+    }
+
     // Identify kind of pattern
 
     // Deal with hostname pattern
@@ -419,7 +428,10 @@ export default class NetworkFilter implements IFilter {
     }
 
     if (filterIndexStart < filterIndexEnd && line.charCodeAt(filterIndexStart) === 124 /* '|' */) {
-      if (filterIndexStart < filterIndexEnd - 1 && line.charCodeAt(filterIndexStart + 1) === 124 /* '|' */) {
+      if (
+        filterIndexStart < filterIndexEnd - 1 &&
+        line.charCodeAt(filterIndexStart + 1) === 124 /* '|' */
+      ) {
         mask = setBit(mask, NETWORK_FILTER_MASK.isHostnameAnchor);
         filterIndexStart += 2;
       } else {
@@ -527,6 +539,7 @@ export default class NetworkFilter implements IFilter {
     let filter: string | undefined;
     if (filterIndexEnd - filterIndexStart > 0) {
       filter = line.slice(filterIndexStart, filterIndexEnd).toLowerCase();
+
       mask = setNetworkMask(mask, NETWORK_FILTER_MASK.isUnicode, hasUnicode(filter));
       if (getBit(mask, NETWORK_FILTER_MASK.isRegex) === false) {
         mask = setNetworkMask(

--- a/test/parsing.test.ts
+++ b/test/parsing.test.ts
@@ -461,6 +461,34 @@ describe('Network filters', () => {
     });
   });
 
+  describe('drops regexp patterns', () => {
+    [
+      '/pattern/',
+      '@@/pattern/',
+      '//',
+      '//$script',
+      '//$image',
+      '//[0-9].*-.*-[a-z0-9]{4}/$script',
+      '/.space/[0-9]{2,9}/$/$script',
+    ].forEach((filter) => {
+      it(filter, () => {
+        expect(NetworkFilter.parse(filter)).toBeNull();
+      });
+    });
+
+    [
+      '||foo.com/pattern/',
+      '||foo.com/pattern/$script',
+      '@@||foo.com/pattern/$script',
+      '@@|foo.com/pattern/$script',
+      '|foo.com/pattern/$script',
+    ].forEach((filter) => {
+      it(filter, () => {
+        expect(NetworkFilter.parse(filter)).not.toBeNull();
+      });
+    });
+  });
+
   describe('options', () => {
     it('accepts any content type', () => {
       network('||foo.com', { fromAny: true });

--- a/test/reverse-index.test.ts
+++ b/test/reverse-index.test.ts
@@ -182,8 +182,8 @@ wildcard
         new ReverseIndex({
           deserialize: NetworkFilter.deserialize,
           filters: parseFilters(`
-/ads/
-/foo/
+/ads^
+/foo^
 -bar-
           `).networkFilters,
         })


### PR DESCRIPTION
We currently do not support RegExp but we still kept them in the engine, this PR makes sur that these filters are detected and dropped.