### PR TITLE
Add built-in error detection code in serialized engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,40 @@
 
 *not released yet*
 
+  * Add built-in error detection code in serialized engine [#165](https://github.com/cliqz-oss/adblocker/pull/165)
+    - To prevent un-noticed data corruptions of the serialized adblocker,
+      FiltersEngine.serialize now automatically includes a crc32 checksum and
+      FiltersEngine.deserialize will automatically check integrity of the given
+      serialized engine. Any mismatch will raise an exception like when the
+      version of the adblocker does not match between the serialized engine and
+      the code using to load it.
   * [BREAKING] `getCosmeticsFilter` API changed to allow finer-grain subsetting
     of cosmetic filters returned: hostname-specific, DOM-specific, generic, etc.
     This allows to inject x70 less custom styles in frames for the same
     blocking, which results in a massive memory decrease as well as less time
-    spent in repaint.
-  * [BREAKING] cosmetic unhide filters without hostname constraints are allowed.
-  * [BREAKING] `NetworkFilter.isCptAllowed` now accept request type as a string.
-  * [BREAKING] drop support for legacy Firefox Bootstrap request types.
-  * Fix matching of hostnames anchors with wildcard.
-  * Add support for `$frame` option in network filters.
-  * Add support for `$document` and `$doc` options in network filters.
-  * Add soft dependency to tldts to simplify API
+    spent in repaint. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * [BREAKING] cosmetic unhide filters without hostname constraints are allowed. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * [BREAKING] `NetworkFilter.isCptAllowed` now accept request type as a string. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * [BREAKING] drop support for legacy Firefox Bootstrap request types. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Fix matching of hostnames anchors with wildcard. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Add support for `$frame` option in network filters. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Add support for `$document` and `$doc` options in network filters. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Add soft dependency to tldts to simplify API [#163](https://github.com/cliqz-oss/adblocker/pull/163)
     - left as require/import in normal bundles
     - bundled in minified bundles
-  * Add tests for Request abstraction
-  * Add static method helpers to create Request instances
+  * Add tests for Request abstraction [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Add static method helpers to create Request instances [#163](https://github.com/cliqz-oss/adblocker/pull/163)
     - `Request.fromRawDetails(...)`
     - `Request.fromWebRequestDetails(...)`
     - `Request.fromPuppeteerDetails(...)`
     - `Request.fromElectronDetails(...)`
-  * Add tests for injection using `jsdom`
-  * Cosmetic filtering performance improvements
+  * Add tests for injection using `jsdom` [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Cosmetic filtering performance improvements [#163](https://github.com/cliqz-oss/adblocker/pull/163)
     - Make use of DOM information to return subset of filters: ids, classes, hrefs
     - Make use of MutationObserver from content-script to return new DOM info
-  * Create integration benchmark to measure full extension
-  * Add Request parsing micro-benchmark
-  * Update bench/comparison to use adblock-rs instead of ad-block
+  * Create integration benchmark to measure full extension [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Add Request parsing micro-benchmark [#163](https://github.com/cliqz-oss/adblocker/pull/163)
+  * Update bench/comparison to use adblock-rs instead of ad-block [#163](https://github.com/cliqz-oss/adblocker/pull/163)
 
 ## 0.9.1
 

--- a/src/crc32.ts
+++ b/src/crc32.ts
@@ -1,0 +1,44 @@
+/* crc32.js (C) 2014-present SheetJS -- http://sheetjs.com */
+/* From: https://github.com/SheetJS/js-crc32/ */
+
+const T: Int32Array = (function signedCrcTable(): Int32Array {
+  let c: number = 0;
+  const table: Int32Array = new Int32Array(256);
+
+  for (let n: number = 0; n !== 256; n += 1) {
+    c = n;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    c = c & 1 ? -306674912 ^ (c >>> 1) : c >>> 1;
+    table[n] = c;
+  }
+
+  return table;
+})();
+
+export default function crc32(buf: Uint8Array, start: number, end: number): number {
+  let C: number = 0 ^ -1;
+  const L: number = end - 7;
+  let i: number = start;
+  for (; i < L; ) {
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+  }
+
+  while (i < L + 7) {
+    C = (C >>> 8) ^ T[(C ^ buf[i++]) & 0xff];
+  }
+
+  return (C ^ -1) >>> 0;
+}

--- a/src/data-view.ts
+++ b/src/data-view.ts
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+import crc32 from './crc32';
 import { decode, encode } from './punycode';
 
 export const EMPTY_UINT8_ARRAY = new Uint8Array(0);
@@ -84,6 +85,10 @@ export default class StaticDataView {
 
     this.buffer = buffer !== undefined ? buffer : new Uint8Array(length);
     this.pos = 0;
+  }
+
+  public checksum(): number {
+    return crc32(this.buffer, 0, this.pos);
   }
 
   public dataAvailable(): boolean {

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -68,6 +68,28 @@ describe('Serialization', () => {
       expect(Engine.deserialize(serialized)).toEqual(engine);
     });
 
+    it('fails with wrong checksum', () => {
+      const engine = new Engine();
+      const serialized = engine.serialize(buffer);
+      for (let i = 0; i < serialized.length; i += 1) {
+        const value = serialized[i];
+        let randomValue = value;
+        while (randomValue === value) {
+          randomValue = Math.floor(Math.random() * 255);
+        }
+        serialized[i] = randomValue;
+
+        // Expect engine to throw
+        expect(() => {
+          Engine.deserialize(serialized);
+        }).toThrow();
+
+        serialized[i] = value;
+      }
+
+      expect(Engine.deserialize(serialized)).toEqual(engine);
+    });
+
     it('handles full engine', () => {
       const engine = new Engine();
       engine.updateResources(loadResources(), 'resources1');


### PR DESCRIPTION
To prevent un-noticed data corruptions of the serialized adblocker, `FiltersEngine.serialize` now automatically includes a `crc32` checksum and `FiltersEngine.deserialize` will automatically check integrity of the given serialized engine. Any mismatch will raise an exception like when the version of the adblocker does not match between the serialized engine and the code using to load it.