### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released yet*
 
+## 0.10.0
+
+*2019-06-05*
+
   * Add helpers to create and manipulate diffs [#172](https://github.com/cliqz-oss/adblocker/pull/172/)
     * `getLinesWithFilters(...)`
     * `generateDiff(...)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -17,7 +17,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 27;
+export const ENGINE_VERSION = 28;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
* Add helpers to create and manipulate diffs [#172](https://github.com/cliqz-oss/adblocker/pull/172/)
  * `getLinesWithFilters(...)`
  * `generateDiff(...)`
  * `mergeDiffs(...)`
* Add `updateFromDiff` method on `FiltersEngine` [#172](https://github.com/cliqz-oss/adblocker/pull/172/)
* Add `getFilters` method on `FiltersEngine` [#172](https://github.com/cliqz-oss/adblocker/pull/172/)
* Fix update issue by performing copy in `StaticDataView.getBytes` [#172](https://github.com/cliqz-oss/adblocker/pull/172/)
* Serialize `config.debug` as well [#172](https://github.com/cliqz-oss/adblocker/pull/172/)
* Implement support for RegExp network filters [#169](https://github.com/cliqz-oss/adblocker/pull/169)
* [EXPERIMENTAL] add on-the-fly string compression using short-string
  optimized method. Off by default, it can be enabled by using the
  `enableCompression` flag in `Config`. This allows a reduction in size of
  about 20% for `FiltersEngine`, at the cost of slightly slower updates. [#122](https://github.com/cliqz-oss/adblocker/pull/122)
* Remove dependency on tslib [#167](https://github.com/cliqz-oss/adblocker/pull/167)
* Add built-in error detection code in serialized engine [#165](https://github.com/cliqz-oss/adblocker/pull/165)
  - To prevent un-noticed data corruptions of the serialized adblocker,
    FiltersEngine.serialize now automatically includes a crc32 checksum and
    FiltersEngine.deserialize will automatically check integrity of the given
    serialized engine. Any mismatch will raise an exception like when the
    version of the adblocker does not match between the serialized engine and
    the code using to load it.
* [BREAKING] `getCosmeticsFilter` API changed to allow finer-grain subsetting
  of cosmetic filters returned: hostname-specific, DOM-specific, generic, etc.
  This allows to inject x70 less custom styles in frames for the same
  blocking, which results in a massive memory decrease as well as less time
  spent in repaint. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* [BREAKING] cosmetic unhide filters without hostname constraints are allowed. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* [BREAKING] `NetworkFilter.isCptAllowed` now accept request type as a string. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* [BREAKING] drop support for legacy Firefox Bootstrap request types. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Fix matching of hostnames anchors with wildcard. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Add support for `$frame` option in network filters. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Add support for `$document` and `$doc` options in network filters. [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Add soft dependency to tldts to simplify API [#163](https://github.com/cliqz-oss/adblocker/pull/163)
  - left as require/import in normal bundles
  - bundled in minified bundles
* Add tests for Request abstraction [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Add static method helpers to create Request instances [#163](https://github.com/cliqz-oss/adblocker/pull/163)
  - `Request.fromRawDetails(...)`
  - `Request.fromWebRequestDetails(...)`
  - `Request.fromPuppeteerDetails(...)`
  - `Request.fromElectronDetails(...)`
* Add tests for injection using `jsdom` [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Cosmetic filtering performance improvements [#163](https://github.com/cliqz-oss/adblocker/pull/163)
  - Make use of DOM information to return subset of filters: ids, classes, hrefs
  - Make use of MutationObserver from content-script to return new DOM info
* Create integration benchmark to measure full extension [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Add Request parsing micro-benchmark [#163](https://github.com/cliqz-oss/adblocker/pull/163)
* Update bench/comparison to use adblock-rs instead of ad-block [#163](https://github.com/cliqz-oss/adblocker/pull/163)