### PR TITLE
FiltersEngine updates stress test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 *not released yet*
 
-  * In `debug` mode, make FiltersEngine creation and updates deterministic
-  * Fix bug in ID computation for `:style(...)` cosmetic filters
-  * Detect invalid cases of `domain=` options for in NetworkFilter
-  * Make `generateDiff` more robust and cover corner case with ID collision
-  * Add stress-test for FiltersEngine updates
+  * In `debug` mode, make FiltersEngine creation and updates deterministic [#176](https://github.com/cliqz-oss/adblocker/pull/176)
+  * Fix bug in ID computation for `:style(...)` cosmetic filters [#176](https://github.com/cliqz-oss/adblocker/pull/176)
+  * Detect invalid cases of `domain=` options in NetworkFilter [#176](https://github.com/cliqz-oss/adblocker/pull/176)
+  * Make `generateDiff` more robust and cover corner case with ID collision [#176](https://github.com/cliqz-oss/adblocker/pull/176)
+  * Add stress-test for FiltersEngine updates. This allows us to validate all past updates of all supported lists [#176](https://github.com/cliqz-oss/adblocker/pull/176)
   * Provide high level puppeteer blocker abstraction [#177](https://github.com/cliqz-oss/adblocker/pull/177)
     * [BREAKING] rename `WebExtensionEngine` into `WebExtensionBlocker`
     * [BREAKING] change format of `redirect` field in blocking response, it now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 *not released yet*
 
+  * In `debug` mode, make FiltersEngine creation and updates deterministic
+  * Fix bug in ID computation for `:style(...)` cosmetic filters
+  * Detect invalid cases of `domain=` options for in NetworkFilter
+  * Make `generateDiff` more robust and cover corner case with ID collision
+  * Add stress-test for FiltersEngine updates
   * Provide high level puppeteer blocker abstraction [#177](https://github.com/cliqz-oss/adblocker/pull/177)
     * [BREAKING] rename `WebExtensionEngine` into `WebExtensionBlocker`
     * [BREAKING] change format of `redirect` field in blocking response, it now

--- a/adblocker.ts
+++ b/adblocker.ts
@@ -13,6 +13,7 @@ export { default as CosmeticFilter } from './src/filters/cosmetic';
 export { default as NetworkFilter } from './src/filters/network';
 export {
   f,
+  parseFilter,
   parseFilters,
   IRawDiff,
   IListDiff,

--- a/bench/micro.js
+++ b/bench/micro.js
@@ -8,7 +8,9 @@
 
 /* eslint-disable no-bitwise */
 
-const { FiltersEngine, fastHash, tokenize, parseFilters, Request } = require('../');
+const {
+  FiltersEngine, tokenize, parseFilters, Request,
+} = require('../');
 const { createEngine, domains500 } = require('./utils');
 
 function benchEngineCreation({ lists, resources }) {
@@ -25,14 +27,6 @@ function benchEngineSerialization({ engine }) {
 
 function benchEngineDeserialization({ serialized }) {
   return FiltersEngine.deserialize(serialized);
-}
-
-function benchStringHashing({ filters }) {
-  let dummy = 0;
-  for (let i = 0; i < filters.length; i += 1) {
-    dummy = (dummy + fastHash(filters[i])) >>> 0;
-  }
-  return dummy;
 }
 
 function benchStringTokenize({ filters }) {
@@ -113,6 +107,5 @@ module.exports = {
   benchGetNetworkTokens,
   benchNetworkFiltersParsing,
   benchRequestParsing,
-  benchStringHashing,
   benchStringTokenize,
 };

--- a/bench/run_benchmark.js
+++ b/bench/run_benchmark.js
@@ -45,7 +45,6 @@ const {
   benchGetCosmeticsFilters,
   benchGetNetworkTokens,
   benchNetworkFiltersParsing,
-  benchStringHashing,
   benchStringTokenize,
   benchRequestParsing,
 } = require('./micro');
@@ -76,7 +75,7 @@ function triggerGC() {
 
 function getMemoryConsumption() {
   triggerGC();
-  return process.memoryUsage().heapUsed;
+  return process.memoryUsage().heapTotal;
 }
 
 /**
@@ -118,7 +117,6 @@ function runMicroBenchmarks(lists, resources) {
     benchGetNetworkTokens,
     benchNetworkFiltersParsing,
     benchRequestParsing,
-    benchStringHashing,
     benchStringTokenize,
   ].forEach((bench) => {
     if (bench.name.toLowerCase().includes(GREP)) {

--- a/src/engine/bucket/filters.ts
+++ b/src/engine/bucket/filters.ts
@@ -111,6 +111,14 @@ export default class FiltersContainer<T extends IFilter> {
       // Store filters in their compact form
       const buffer = StaticDataView.allocate(bufferSizeEstimation, this.config);
       buffer.pushUint32(selected.length);
+
+      // When we run in `debug` mode, we enable fully deterministic updates of
+      // internal data-structure. To this effect, we sort all filters before
+      // insertion.
+      if (this.config.debug === true) {
+        selected.sort((f1: T, f2: T): number => f1.getId() - f2.getId());
+      }
+
       for (let i = 0; i < selected.length; i += 1) {
         selected[i].serialize(buffer);
       }

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -177,10 +177,11 @@ export default class FilterEngine {
 
     // Serialize the state of lists (names and checksums)
     buffer.pushUint16(this.lists.size);
-    this.lists.forEach((checksum, name) => {
-      buffer.pushASCII(name);
-      buffer.pushASCII(checksum);
-    });
+    const entries = Array.from(this.lists.entries()).sort();
+    for (let i = 0; i < entries.length; i += 1) {
+      buffer.pushASCII(entries[i][0]);
+      buffer.pushASCII(entries[i][1]);
+    }
 
     // Filters buckets
     this.filters.serialize(buffer);

--- a/src/engine/reverse-index.ts
+++ b/src/engine/reverse-index.ts
@@ -351,25 +351,33 @@ export default class ReverseIndex<T extends IFilter> {
 
     // Compute tokens for all filters (the ones already contained in the index
     // *plus* the new ones *minus* the ones removed ).
-    const filtersArrays = [this.getFilters(), newFilters];
-    for (let h = 0; h < filtersArrays.length; h += 1) {
-      const filters = filtersArrays[h];
-      for (let i = 0; i < filters.length; i += 1) {
-        const filter = filters[i];
-        if (removedFilters === undefined || removedFilters.has(filter.getId()) === false) {
-          const multiTokens = filter.getTokens();
-          filtersTokens.push({
-            filter,
-            multiTokens,
-          });
+    const filters = this.getFilters();
+    for (let i = 0; i < newFilters.length; i += 1) {
+      filters.push(newFilters[i]);
+    }
 
-          for (let j = 0; j < multiTokens.length; j += 1) {
-            const tokens = multiTokens[j];
-            totalNumberOfIndexedFilters += 1;
-            for (let k = 0; k < tokens.length; k += 1) {
-              totalNumberOfTokens += 1;
-              histogram.incr(tokens[k]);
-            }
+    // When we run in `debug` mode, we enable fully deterministic updates of
+    // internal data-structure. To this effect, we sort all filters before
+    // insertion.
+    if (this.config.debug === true) {
+      filters.sort((f1: T, f2: T): number => f1.getId() - f2.getId());
+    }
+
+    for (let i = 0; i < filters.length; i += 1) {
+      const filter = filters[i];
+      if (removedFilters === undefined || removedFilters.has(filter.getId()) === false) {
+        const multiTokens = filter.getTokens();
+        filtersTokens.push({
+          filter,
+          multiTokens,
+        });
+
+        for (let j = 0; j < multiTokens.length; j += 1) {
+          const tokens = multiTokens[j];
+          totalNumberOfIndexedFilters += 1;
+          for (let k = 0; k < tokens.length; k += 1) {
+            totalNumberOfTokens += 1;
+            histogram.incr(tokens[k]);
           }
         }
       }

--- a/src/filters/cosmetic.ts
+++ b/src/filters/cosmetic.ts
@@ -190,6 +190,7 @@ function computeFilterId(
   entities: Uint32Array | undefined,
   notHostnames: Uint32Array | undefined,
   notEntities: Uint32Array | undefined,
+  style: string | undefined,
 ): number {
   let hash = (5408 * 33) ^ mask;
 
@@ -220,6 +221,12 @@ function computeFilterId(
   if (notEntities !== undefined) {
     for (let i = 0; i < notEntities.length; i += 1) {
       hash = (hash * 33) ^ notEntities[i];
+    }
+  }
+
+  if (style !== undefined) {
+    for (let i = 0; i < style.length; i += 1) {
+      hash = (hash * 33) ^ style.charCodeAt(i);
     }
   }
 
@@ -894,6 +901,7 @@ export default class CosmeticFilter implements IFilter {
         this.entities,
         this.notHostnames,
         this.notEntities,
+        this.style,
       );
     }
     return this.id;

--- a/src/filters/network.ts
+++ b/src/filters/network.ts
@@ -280,6 +280,13 @@ export default class NetworkFilter implements IFilter {
 
         switch (option) {
           case 'domain': {
+            // domain list starting or ending with '|' is invalid
+            if (
+              optionValue.charCodeAt(0) === 124 /* '|' */ ||
+              optionValue.charCodeAt(optionValue.length - 1) === 124 /* '|' */
+            ) {
+              return null;
+            }
             const optionValues: string[] = optionValue.split('|');
             const optDomainsArray: number[] = [];
             const optNotDomainsArray: number[] = [];

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -189,7 +189,7 @@ export function getLinesWithFilters(
   raw: string,
   config: Partial<Config> = new Config(),
 ): Set<string> {
-  config = new Config(Object.assign(config, { debug: true }));
+  config = new Config(Object.assign({}, config, { debug: true }));
 
   const {
     networkFilters,
@@ -210,9 +210,13 @@ export function getLinesWithFilters(
  * Given two versions of the same subscription (e.g.: EasyList) as a string,
  * generate a raw diff (i.e.: a list of lines added and lines removed).
  */
-export function generateDiff(prevRevision: string, newRevision: string): IRawDiff {
-  const prevRevisionLines: Set<string> = getLinesWithFilters(prevRevision);
-  const newRevisionLines: Set<string> = getLinesWithFilters(newRevision);
+export function generateDiff(
+  prevRevision: string,
+  newRevision: string,
+  config: Partial<Config> = new Config(),
+): IRawDiff {
+  const prevRevisionLines: Set<string> = getLinesWithFilters(prevRevision, config);
+  const newRevisionLines: Set<string> = getLinesWithFilters(newRevision, config);
 
   const added: string[] = [];
   const removed: string[] = [];

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -185,16 +185,19 @@ export interface IRawDiff {
  * guaranteed to be a valid filter (i.e.: comments, empty lines and
  * un-supported filters are dropped).
  */
-export function getLinesWithFilters(raw: string): Set<string> {
+export function getLinesWithFilters(
+  raw: string,
+  config: Partial<Config> = new Config(),
+): Set<string> {
+  config = new Config(Object.assign(config, { debug: true }));
+
   const {
     networkFilters,
     cosmeticFilters,
   }: {
     networkFilters: NetworkFilter[];
     cosmeticFilters: CosmeticFilter[];
-  } = parseFilters(raw, {
-    debug: true,
-  });
+  } = parseFilters(raw, config);
 
   return new Set(
     networkFilters
@@ -262,7 +265,7 @@ export function mergeDiffs(diffs: Array<Partial<IRawDiff>>): IRawDiff {
   }
 
   return {
-    added: Array.from(addedCumul),
-    removed: Array.from(removedCumul),
+    added: Array.from(addedCumul).sort(),
+    removed: Array.from(removedCumul).sort(),
   };
 }

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -114,17 +114,20 @@ function detectFilterType(line: string): FilterType {
   return FilterType.NETWORK;
 }
 
-export function f(strings: TemplateStringsArray): NetworkFilter | CosmeticFilter | null {
-  const rawFilter = strings[0];
-  const filterType = detectFilterType(rawFilter);
+export function parseFilter(filter: string): NetworkFilter | CosmeticFilter | null {
+  const filterType = detectFilterType(filter);
 
   if (filterType === FilterType.NETWORK) {
-    return NetworkFilter.parse(rawFilter, true);
+    return NetworkFilter.parse(filter, true);
   } else if (filterType === FilterType.COSMETIC) {
-    return CosmeticFilter.parse(rawFilter, true);
+    return CosmeticFilter.parse(filter, true);
   }
 
   return null;
+}
+
+export function f(strings: TemplateStringsArray): NetworkFilter | CosmeticFilter | null {
+  return parseFilter(strings[0]);
 }
 
 export function parseFilters(
@@ -168,6 +171,15 @@ export function parseFilters(
   return { networkFilters, cosmeticFilters };
 }
 
+function getFilters(
+  list: string,
+  config?: Partial<Config>,
+): Array<NetworkFilter | CosmeticFilter> {
+  const { networkFilters, cosmeticFilters } = parseFilters(list, config);
+  const filters: Array<NetworkFilter | CosmeticFilter> = [];
+  return filters.concat(networkFilters).concat(cosmeticFilters);
+}
+
 export interface IListDiff {
   newNetworkFilters: NetworkFilter[];
   newCosmeticFilters: CosmeticFilter[];
@@ -186,54 +198,53 @@ export interface IRawDiff {
  * un-supported filters are dropped).
  */
 export function getLinesWithFilters(
-  raw: string,
+  list: string,
   config: Partial<Config> = new Config(),
 ): Set<string> {
-  config = new Config(Object.assign({}, config, { debug: true }));
-
-  const {
-    networkFilters,
-    cosmeticFilters,
-  }: {
-    networkFilters: NetworkFilter[];
-    cosmeticFilters: CosmeticFilter[];
-  } = parseFilters(raw, config);
-
+  // Set config to `debug` so that we keep track of raw lines for each filter
   return new Set(
-    networkFilters
-      .map((filter) => filter.rawLine as string)
-      .concat(cosmeticFilters.map((filter) => filter.rawLine as string)),
+    getFilters(list, new Config(Object.assign({}, config, { debug: true }))).map(
+      ({ rawLine }) => rawLine as string,
+    ),
   );
 }
 
 /**
  * Given two versions of the same subscription (e.g.: EasyList) as a string,
- * generate a raw diff (i.e.: a list of lines added and lines removed).
+ * generate a raw diff (i.e.: a list of filters added and filters removed, in
+ * their raw string form).
  */
 export function generateDiff(
   prevRevision: string,
   newRevision: string,
   config: Partial<Config> = new Config(),
 ): IRawDiff {
-  const prevRevisionLines: Set<string> = getLinesWithFilters(prevRevision, config);
-  const newRevisionLines: Set<string> = getLinesWithFilters(newRevision, config);
+  // Set config to `debug` so that we keep track of raw lines for each filter
+  const debugConfig = new Config(Object.assign({}, config, { debug: true }));
 
-  const added: string[] = [];
-  const removed: string[] = [];
+  const prevRevisionFilters = getFilters(prevRevision, debugConfig);
+  const prevRevisionIds = new Set(prevRevisionFilters.map((filter) => filter.getId()));
 
-  newRevisionLines.forEach((line) => {
-    if (!prevRevisionLines.has(line)) {
-      added.push(line);
+  const newRevisionFilters = getFilters(newRevision, debugConfig);
+  const newRevisionIds = new Set(newRevisionFilters.map((filter) => filter.getId()));
+
+  // Check which filters were added, based on ID
+  const added: Set<string> = new Set();
+  newRevisionFilters.forEach((filter) => {
+    if (!prevRevisionIds.has(filter.getId())) {
+      added.add(filter.rawLine as string);
     }
   });
 
-  prevRevisionLines.forEach((line) => {
-    if (!newRevisionLines.has(line)) {
-      removed.push(line);
+  // Check which filters were removed, based on ID
+  const removed: Set<string> = new Set();
+  prevRevisionFilters.forEach((filter) => {
+    if (!newRevisionIds.has(filter.getId())) {
+      removed.add(filter.rawLine as string);
     }
   });
 
-  return { added, removed };
+  return { added: Array.from(added), removed: Array.from(removed) };
 }
 
 /**
@@ -269,7 +280,7 @@ export function mergeDiffs(diffs: Array<Partial<IRawDiff>>): IRawDiff {
   }
 
   return {
-    added: Array.from(addedCumul).sort(),
-    removed: Array.from(removedCumul).sort(),
+    added: Array.from(addedCumul),
+    removed: Array.from(removedCumul),
   };
 }

--- a/src/lists.ts
+++ b/src/lists.ts
@@ -230,19 +230,21 @@ export function generateDiff(
 
   // Check which filters were added, based on ID
   const added: Set<string> = new Set();
-  newRevisionFilters.forEach((filter) => {
+  for (let i = 0; i < newRevisionFilters.length; i += 1) {
+    const filter = newRevisionFilters[i];
     if (!prevRevisionIds.has(filter.getId())) {
       added.add(filter.rawLine as string);
     }
-  });
+  }
 
   // Check which filters were removed, based on ID
   const removed: Set<string> = new Set();
-  prevRevisionFilters.forEach((filter) => {
+  for (let i = 0; i < prevRevisionFilters.length; i += 1) {
+    const filter = prevRevisionFilters[i];
     if (!newRevisionIds.has(filter.getId())) {
       removed.add(filter.rawLine as string);
     }
-  });
+  }
 
   return { added: Array.from(added), removed: Array.from(removed) };
 }

--- a/test/engine-update.test.ts
+++ b/test/engine-update.test.ts
@@ -9,10 +9,6 @@
 import { FiltersEngine } from '../adblocker';
 import { loadEasyListFilters, typedArrayEqual } from './utils';
 
-import axios from 'axios';
-import { brotliDecompressSync } from 'zlib';
-import { generateDiff } from '../adblocker';
-
 describe('diff updates', () => {
   function testUpdates(name: string, baseFilters: string[]): void {
     describe(name, () => {
@@ -74,102 +70,4 @@ describe('diff updates', () => {
 
   testUpdates('empty engine', []);
   testUpdates('easylist engine', loadEasyListFilters());
-});
-
-/**
- * This test should not run as part of the regular test-suite because it takes
- * too long. On the other hand, it can be useful to run it from time to time to
- * make sure that engine updates work on all available diffs from CDN.
- */
-describe.skip('stress test', () => {
-  jest.setTimeout(3000000);
-
-  function urlOfRevision(list: string, rev: string): string {
-    return `https://cdn.cliqz.com/adblocker/resources/${list}/${rev}/list.txt`;
-  }
-
-  const REVISIONS_CACHE: Map<string, string> = new Map();
-
-  async function getRevision(url: string): Promise<string> {
-    const cached = REVISIONS_CACHE.get(url);
-    if (cached !== undefined) {
-      return cached;
-    }
-
-    let data = (await axios.get(url)).data;
-
-    if (!data.startsWith('[Ad')) {
-      const buffer = Buffer.from(
-        (await axios.get(url, {
-          responseType: 'arraybuffer',
-        })).data,
-      );
-      data = brotliDecompressSync(buffer).toString('utf-8');
-    }
-
-    REVISIONS_CACHE.set(url, data);
-
-    return data;
-  }
-
-  const ENGINES_CACHE: Map<string, Uint8Array> = new Map();
-
-  function getEngine(list: string): Uint8Array {
-    const cached = ENGINES_CACHE.get(list);
-    if (cached !== undefined) {
-      return cached.slice();
-    }
-
-    const engine = FiltersEngine.parse(list, { debug: true });
-    const serialized = engine.serialize();
-    ENGINES_CACHE.set(list, serialized);
-
-    return serialized.slice();
-  }
-
-  for (const list of ['easyprivacy', 'easylist']) {
-    it(list, async () => {
-      const meta = (await axios.get(
-        `https://cdn.cliqz.com/adblocker/resources/${list}/metadata.json`,
-      )).data;
-
-      // Skip the first one which will not have any previous rev
-      const previousRevisions = [...meta.previousRevisions, meta.latestRevision];
-      for (let i = 1; i < previousRevisions.length; i += 1) {
-        const currentRevision = previousRevisions[i];
-        const currentList = await getRevision(urlOfRevision(list, currentRevision));
-
-        for (let j = Math.max(i - 7, 0); j < i; j += 1) {
-          const previousRevision = previousRevisions[j];
-          const previousList = await getRevision(urlOfRevision(list, previousRevision));
-
-          // Generate diff between two versions
-          const diff = generateDiff(previousList, currentList);
-
-          // Check that previous rev and current rev do not yield the same Engine
-          const currentEngine = FiltersEngine.deserialize(getEngine(currentList));
-          const previousEngineSerialized = getEngine(previousList);
-          expect(currentEngine).not.toEqual(FiltersEngine.deserialize(previousEngineSerialized));
-
-          // Update `previousEngine` with diff and expect to find `currentEngine`
-          const previousEngine = FiltersEngine.deserialize(previousEngineSerialized);
-          const updated = previousEngine.updateFromDiff(diff);
-          expect(updated).toBe(true);
-
-          const updatedEngineFilters = previousEngine.getFilters();
-          const currentEngineFilters = currentEngine.getFilters();
-
-          // Check that cosmetic filters are the same
-          expect(new Set(updatedEngineFilters.cosmeticFilters.map((f) => f.toString()))).toEqual(
-            new Set(currentEngineFilters.cosmeticFilters.map((f) => f.toString())),
-          );
-
-          // Check that network filters are the same
-          expect(new Set(updatedEngineFilters.networkFilters.map((f) => f.toString()))).toEqual(
-            new Set(currentEngineFilters.networkFilters.map((f) => f.toString())),
-          );
-        }
-      }
-    });
-  }
 });

--- a/test/lists.test.ts
+++ b/test/lists.test.ts
@@ -6,7 +6,106 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { f, mergeDiffs } from '../src/lists';
+import { f, generateDiff, getLinesWithFilters, mergeDiffs } from '../src/lists';
+
+describe('#getLinesWithFilters', () => {
+  it('get not lines if empty', () => {
+    expect(getLinesWithFilters('')).toEqual(new Set());
+  });
+
+  it('handle single filter', () => {
+    expect(getLinesWithFilters('||foo.com$badfilter')).toEqual(new Set(['||foo.com$badfilter']));
+  });
+
+  it('handle multiple filters', () => {
+    expect(getLinesWithFilters('||foo.com$badfilter\n||bar.co.uk')).toEqual(
+      new Set(['||foo.com$badfilter', '||bar.co.uk']),
+    );
+  });
+
+  it('ignore empty lines', () => {
+    expect(
+      getLinesWithFilters(`
+
+||foo.com
+
+
+bar.co.uk^*baz
+
+      `),
+    ).toEqual(new Set(['||foo.com', 'bar.co.uk^*baz']));
+  });
+
+  it('ignore comments', () => {
+    expect(
+      getLinesWithFilters(`
+[Adblock Plus 2.0]
+! this is a comment
+||foo.com
+
+
+!bar.co.uk^*baz
+
+      `),
+    ).toEqual(new Set(['||foo.com']));
+  });
+});
+
+describe('#generateDiff', () => {
+  it('diff between empty strings', () => {
+    expect(generateDiff('', '')).toEqual({
+      added: [],
+      removed: [],
+    });
+  });
+
+  it('same filters', () => {
+    expect(
+      generateDiff(
+        `
+||foo.com
+
+bar.baz
+*ads*
+
+    `,
+        `
+! comment
+
+bar.baz
+*ads*
+||foo.com
+    `,
+      ),
+    ).toEqual({
+      added: [],
+      removed: [],
+    });
+  });
+
+  it('add filters from empty', () => {
+    expect(generateDiff('', '||foo.com')).toEqual({
+      added: ['||foo.com'],
+      removed: [],
+    });
+  });
+
+  it('remove filters', () => {
+    expect(generateDiff('||foo.com', '')).toEqual({
+      added: [],
+      removed: ['||foo.com'],
+    });
+  });
+
+  it('handle filter renaming', () => {
+    expect(
+      generateDiff('||foo.com$domain=foo.com|bar.com', '||foo.com$domain=bar.com|foo.com'),
+    ).toEqual({
+      added: [],
+      removed: [],
+    });
+  });
+});
 
 describe('#f', () => {
   it('handles CosmeticFilter', () => {

--- a/test/stress-test-engine-update.ts
+++ b/test/stress-test-engine-update.ts
@@ -12,7 +12,6 @@
  */
 
 import axios from 'axios';
-import { writeFileSync } from 'fs';
 import { brotliDecompressSync } from 'zlib';
 import {
   Config,
@@ -21,7 +20,7 @@ import {
   getLinesWithFilters,
   parseFilter,
 } from '../adblocker';
-import { typedArrayDiff, typedArrayEqual } from './utils';
+import { typedArrayEqual } from './utils';
 
 /**
  * Convert `option` into its normalized version, if any. Otherwise return the

--- a/test/stress-test-engine-update.ts
+++ b/test/stress-test-engine-update.ts
@@ -1,0 +1,390 @@
+/**
+ * This script can be used to stress-test the adblocker and validate our filter
+ * builder at the same time. In a nutshell, it will download all the supported
+ * lists (available on CDN), as well as all the possible diffs from one version
+ * to the next for each list then perform the following:
+ *
+ * 1. check: FiltersEngine can be initialized from list
+ * 2. check: FiltersEngine can be updated with diff
+ * 3. check: serialized version of FiltersEngine is byte-identical after update
+ * 4. check: serialized versions can be de-serialized into the same FiltersEngine
+ * 5. check: no ID collisions for filters
+ */
+
+import axios from 'axios';
+import { writeFileSync } from 'fs';
+import { brotliDecompressSync } from 'zlib';
+import {
+  Config,
+  FiltersEngine,
+  generateDiff,
+  getLinesWithFilters,
+  parseFilter,
+} from '../adblocker';
+import { typedArrayDiff, typedArrayEqual } from './utils';
+
+/**
+ * Convert `option` into its normalized version, if any. Otherwise return the
+ * option un-changed. For example `stylesheet` will be normalized to `css`.
+ * This particular helper could eventually be included in the adblocker library
+ * directly but it is not yet clear if the expected performance overhead is
+ * worth it.
+ */
+function replacer(option: string): string {
+  switch (option) {
+    case 'third-party':
+      return '3p';
+    case 'first-party':
+      return '1p';
+    case 'object-subrequest':
+      return 'object';
+    case 'stylesheet':
+      return 'css';
+    case 'subdocument':
+      return 'frame';
+    case 'xmlhttprequest':
+      return 'xhr';
+    case 'document':
+      return 'doc';
+    default:
+      return 'option';
+  }
+}
+
+/**
+ * Normalize a raw filter by replacing options with their canonical forms. For
+ * example `||foo.com$stylesheet,first-party,xhr` would be normalized to
+ * `||foo.com$css,1p,xhr`.
+ */
+const REGEX = /third-party|first-party|object-subrequest|stylesheet|subdocument|xmlhttprequest|document/g;
+function normalizeFilters(rawFilter: string): string {
+  const indexOfOptions = rawFilter.lastIndexOf('$');
+  if (indexOfOptions === -1) {
+    return rawFilter;
+  }
+
+  REGEX.lastIndex = indexOfOptions;
+  return rawFilter.replace(REGEX, replacer);
+}
+
+/**
+ * Global config used for all `FiltersEngine`. This allows to change options
+ * globally without having to change all used configs.
+ */
+const ENGINE_CONFIG = new Config({
+  debug: true,
+});
+
+/**
+ * Make sure instances of CosmeticFilter and NetworkFilter from strings in
+ * `filters` do not yield any IDs collision. In otherwise, check that there are
+ * not any two filters from `filters` with the same ID.
+ */
+function checkIdCollisions(filters: Set<string>): string[] {
+  const collisions: string[] = [];
+
+  const ids: Map<number, string> = new Map();
+  for (const line of Array.from(filters)) {
+    const filter = parseFilter(line);
+    if (filter !== null) {
+      const id = filter.getId();
+      if (ids.has(id)) {
+        collisions.push(`${line} collides with ${ids.get(id)}`);
+      } else {
+        ids.set(id, line);
+      }
+    }
+  }
+
+  return collisions;
+}
+
+/**
+ * Given two sets of filters (in raw string form), return a list of differences
+ * between them (i.e.: filters in one set but not the other).
+ */
+function filtersDiff(
+  name1: string,
+  filters1: Set<string>,
+  name2: string,
+  filters2: Set<string>,
+): string[] {
+  const differences: string[] = [];
+  for (const f of Array.from(filters1)) {
+    if (!filters2.has(f)) {
+      differences.push(`Filter in ${name1} but not ${name2}: ${f}`);
+    }
+  }
+
+  for (const f of Array.from(filters2)) {
+    if (!filters1.has(f)) {
+      differences.push(`Filter in ${name2} but not ${name1}: ${f}`);
+    }
+  }
+
+  return differences;
+}
+
+async function getMeta(url: string): Promise<any> {
+  const meta = (await axios.get(url)).data;
+  if (typeof meta === 'string') {
+    const buffer = Buffer.from(
+      (await axios.get(url, {
+        responseType: 'arraybuffer',
+      })).data,
+    );
+    return JSON.parse(brotliDecompressSync(buffer).toString('utf-8'));
+  }
+
+  return meta;
+}
+
+/**
+ * Return the CDN URL of a specific revision `rev` (a hash) of subscription `list` (e.g. 'easylist').
+ */
+function urlOfRevision(list: string, rev: string): string {
+  return `https://cdn.cliqz.com/adblocker/resources/${list}/${rev}/list.txt`;
+}
+
+/**
+ * Fetch a list from CDN (given its URL). Apart from performing the fetching,
+ * we also take care of detecting if the list was compressed using brotli
+ * (which was the case before; then we switched to gzip for broader
+ * compatibility).
+ */
+const REVISIONS_CACHE: Map<string, string> = new Map();
+async function getRevision(url: string): Promise<string> {
+  const cached = REVISIONS_CACHE.get(url);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let data = (await axios.get(url)).data;
+  if (!data.startsWith('[Ad')) {
+    const buffer = Buffer.from(
+      (await axios.get(url, {
+        responseType: 'arraybuffer',
+      })).data,
+    );
+    try {
+      data = brotliDecompressSync(buffer).toString('utf-8');
+    } catch (ex) {
+      // Data is probably already decompressed
+    }
+  }
+
+  REVISIONS_CACHE.set(url, data);
+
+  return data;
+}
+
+/**
+ * Return a set of filters (in their raw string form) from raw list. Also takes
+ * care of normalizing options (e.g.: `stylesheet` -> `css`).
+ */
+function getFiltersFromList(list: string): Set<string> {
+  return new Set(Array.from(getLinesWithFilters(list, ENGINE_CONFIG)).map(normalizeFilters));
+}
+
+/**
+ * Return set of filters (in their raw string form) from a `FiltersEngine` instance.
+ */
+function getFiltersFromEngine(engine: FiltersEngine): Set<string> {
+  const { networkFilters, cosmeticFilters } = engine.getFilters();
+
+  return new Set([
+    ...networkFilters.map(({ rawLine }) => normalizeFilters(rawLine as string)),
+    ...cosmeticFilters.map(({ rawLine }) => normalizeFilters(rawLine as string)),
+  ]);
+}
+
+/**
+ * Return a serialized version of the `FiltersEngine` instance initialized from
+ * `list`. Takes care of caching engines initialized from the same list and
+ * return a copy of the serialized version to make sure no mutation is
+ * possible.
+ */
+const ENGINES_CACHE: Map<string, Uint8Array> = new Map();
+function getEngineFromList(list: string): Uint8Array {
+  const cached = ENGINES_CACHE.get(list);
+  if (cached !== undefined) {
+    return cached.slice();
+  }
+
+  const engine = new FiltersEngine({ config: ENGINE_CONFIG });
+  engine.updateFromDiff({
+    added: Array.from(getFiltersFromList(list)),
+  });
+  const serialized = engine.serialize();
+
+  ENGINES_CACHE.set(list, serialized);
+
+  return serialized.slice();
+}
+
+interface ITestCase {
+  currentList: string;
+  currentRevision: string;
+  previousList: string;
+  previousRevision: string;
+}
+
+/**
+ * Fetch all versions of subscription `list` as well as all the available
+ * updates (i.e.: diffs) from CDN. These will then be used to make sure all
+ * updates are valid and that FiltersEngine can always be updated from them.
+ */
+async function collectTestCases(list: string) {
+  const cases: Array<{
+    currentRevision: string;
+    previousRevision: string;
+  }> = [];
+  const meta = await getMeta(`https://cdn.cliqz.com/adblocker/resources/${list}/metadata.json`);
+  const revisions: Set<string> = new Set();
+
+  // Append current revision (the most recent one)
+  const previousRevisions = [...meta.previousRevisions, meta.latestRevision];
+
+  // Skip the first one which will not have any previous rev
+  for (let i = 1; i < previousRevisions.length; i += 1) {
+    const currentRevision = previousRevisions[i];
+    revisions.add(currentRevision);
+    for (let j = Math.max(i - 7, 0); j < i; j += 1) {
+      const previousRevision = previousRevisions[j];
+      revisions.add(previousRevision);
+      cases.push({
+        currentRevision,
+        previousRevision,
+      });
+    }
+  }
+
+  // Fetch revisions
+  await Promise.all(
+    Array.from(revisions).map((revision) => getRevision(urlOfRevision(list, revision))),
+  );
+
+  const testCases: ITestCase[] = [];
+  for (const { previousRevision, currentRevision } of cases) {
+    const previousList = REVISIONS_CACHE.get(urlOfRevision(list, previousRevision));
+    const currentList = REVISIONS_CACHE.get(urlOfRevision(list, currentRevision));
+
+    if (previousList !== undefined && currentList !== undefined) {
+      testCases.push({
+        currentList,
+        currentRevision,
+        previousList,
+        previousRevision,
+      });
+    }
+  }
+
+  return testCases;
+}
+
+/**
+ * Start stress-test!
+ */
+async function run() {
+  for (const list of [
+    'cliqz-filters',
+    'easylist',
+    'easyprivacy',
+    'plowe-0',
+    'ublock-abuse',
+    'ublock-badware',
+    'ublock-filters',
+    'ublock-privacy',
+    'ublock-unbreak',
+    'whotracksme-filters',
+  ]) {
+    console.log(`> ${list}`);
+    const testCases = await collectTestCases(list);
+    REVISIONS_CACHE.clear();
+
+    for (const { previousRevision, currentRevision, currentList, previousList } of testCases) {
+      console.log(` + ${previousRevision} => ${currentRevision}`);
+
+      // Generate diff between two versions
+      let diff = generateDiff(previousList, currentList, ENGINE_CONFIG);
+      diff = {
+        added: diff.added.map(normalizeFilters),
+        removed: diff.removed.map(normalizeFilters),
+      };
+
+      // Check that previous rev and current rev do not yield the same Engine
+      const currentEngineSerialized = getEngineFromList(currentList);
+      const previousEngineSerialized = getEngineFromList(previousList);
+      const previousEngine = FiltersEngine.deserialize(previousEngineSerialized);
+
+      if (typedArrayEqual(currentEngineSerialized, previousEngineSerialized)) {
+        throw new Error('Expected engines to not be equal');
+      }
+
+      // Update `previousEngine` with diff and expect to find `currentEngine`
+      const updated = previousEngine.updateFromDiff(diff);
+      if (updated === false) {
+        throw new Error('Expected engine to have been updated');
+      }
+
+      // Check filters are the same
+      const filtersFromList = getFiltersFromList(currentList);
+
+      const collisions = checkIdCollisions(filtersFromList);
+      if (collisions.length !== 0) {
+        console.log('Found ID collisions');
+        for (const collision of collisions) {
+          console.log(collision);
+        }
+      }
+
+      const filtersFromCurrentEngine = getFiltersFromEngine(
+        FiltersEngine.deserialize(currentEngineSerialized),
+      );
+      const filtersFromUpdatedEngine = getFiltersFromEngine(previousEngine);
+
+      const diff1 = filtersDiff('fromList', filtersFromList, 'fromFull', filtersFromCurrentEngine);
+      if (diff1.length !== 0) {
+        console.log('Found discrepancy in filters');
+        for (const difference of diff1) {
+          console.log(difference);
+        }
+      }
+
+      const diff2 = filtersDiff(
+        'fromList',
+        filtersFromList,
+        'fromUpdated',
+        filtersFromUpdatedEngine,
+      );
+      if (diff2.length !== 0) {
+        console.log('Found discrepancy in filters');
+        for (const difference of diff2) {
+          console.log(difference);
+        }
+      }
+
+      const updatedEngineSerialized = previousEngine.serialize();
+      if (typedArrayEqual(updatedEngineSerialized, currentEngineSerialized) === false) {
+        console.error('> DIFF', typedArrayDiff(updatedEngineSerialized, currentEngineSerialized));
+        // throw new Error('Expected serialized engines to be equal');
+        writeFileSync('issue_prev_list', previousList, { encoding: 'utf-8' });
+        writeFileSync('issue_curr_list', currentList, { encoding: 'utf-8' });
+        writeFileSync('issue_diff', JSON.stringify(diff), { encoding: 'utf-8' });
+        return;
+      }
+
+      // Make sure we can re-serialize on top of updated engine
+      const reSerialized = FiltersEngine.deserialize(updatedEngineSerialized).serialize();
+      if (typedArrayEqual(reSerialized, currentEngineSerialized) === false) {
+        console.error('> DIFF', typedArrayDiff(reSerialized, currentEngineSerialized));
+        // console.error('> DIFF', diff);
+        // throw new Error('Expected re-serialized engines to be equal');
+      }
+    }
+
+    ENGINES_CACHE.clear();
+  }
+}
+
+run();

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -47,21 +47,34 @@ export function getNaughtyStrings(): string[] {
   return fs.readFileSync(path.resolve(__dirname, 'data', 'blns.txt'), 'utf-8').split('\n');
 }
 
-export function typedArrayEqual(arr1: Uint8Array, arr2: Uint8Array): boolean {
+export function typedArrayDiff(arr1: Uint8Array, arr2: Uint8Array): string[] {
+  const differences: string[] = [];
   if (arr1.byteLength !== arr2.byteLength) {
-    return false;
+    differences.push(
+      `Diff (length): ${JSON.stringify({
+        arr1_length: arr1.byteLength,
+        arr2_length: arr2.byteLength,
+      })}`,
+    );
+    return differences;
   }
 
   for (let i = 0; i < arr1.byteLength; i += 1) {
     if (arr1[i] !== arr2[i]) {
-      console.log('Diff', {
-        arr1: arr1[i],
-        arr2: arr2[i],
-        i,
-      });
-      return false;
+      differences.push(
+        `Diff (values): ${JSON.stringify({
+          arr1: arr1[i],
+          arr2: arr2[i],
+          i,
+        })}`,
+      );
+      break;
     }
   }
 
-  return true;
+  return differences;
+}
+
+export function typedArrayEqual(arr1: Uint8Array, arr2: Uint8Array): boolean {
+  return typedArrayDiff(arr1, arr2).length === 0;
 }


### PR DESCRIPTION
  * In `debug` mode, make FiltersEngine creation and updates deterministic
  * Fix bug in ID computation for `:style(...)` cosmetic filters
  * Detect invalid cases of `domain=` options in NetworkFilter
  * Make `generateDiff` more robust and cover corner case with ID collision
  * Add stress-test for FiltersEngine updates. This allows us to validate all past updates of all supported lists