### PR TITLE
Release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released yet*
 
+## 0.11.0
+
+*2019-06-17*
+
   * In `debug` mode, make FiltersEngine creation and updates deterministic [#176](https://github.com/cliqz-oss/adblocker/pull/176)
   * Fix bug in ID computation for `:style(...)` cosmetic filters [#176](https://github.com/cliqz-oss/adblocker/pull/176)
   * Detect invalid cases of `domain=` options in NetworkFilter [#176](https://github.com/cliqz-oss/adblocker/pull/176)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Cliqz adblocker library",
   "repository": {
     "type": "git",

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -17,7 +17,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 28;
+export const ENGINE_VERSION = 29;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
  * In `debug` mode, make FiltersEngine creation and updates deterministic [#176](https://github.com/cliqz-oss/adblocker/pull/176)
  * Fix bug in ID computation for `:style(...)` cosmetic filters [#176](https://github.com/cliqz-oss/adblocker/pull/176)
  * Detect invalid cases of `domain=` options in NetworkFilter [#176](https://github.com/cliqz-oss/adblocker/pull/176)
  * Make `generateDiff` more robust and cover corner case with ID collision [#176](https://github.com/cliqz-oss/adblocker/pull/176)
  * Add stress-test for FiltersEngine updates. This allows us to validate all past updates of all supported lists [#176](https://github.com/cliqz-oss/adblocker/pull/176)
  * Provide high level puppeteer blocker abstraction [#177](https://github.com/cliqz-oss/adblocker/pull/177)
    * [BREAKING] rename `WebExtensionEngine` into `WebExtensionBlocker`
    * [BREAKING] change format of `redirect` field in blocking response, it now
      exposes more information about the redirected resource: `contentType`,
      `body` and `dataUrl` (which was the only information originally returned
      by `FiltersEngine.match(...)`).
    * Rename `example` into `examples` and move test webextension into `examples/webextension`
  * Add missing dependencies on @types/puppeteer needed by users of the library [#174](https://github.com/cliqz-oss/adblocker/pull/174/)
