### PR TITLE
Allow the 'not' pseudoclass in cosmetic filters

### DIFF
--- a/src/filters/cosmetic.ts
+++ b/src/filters/cosmetic.ts
@@ -398,7 +398,6 @@ export default class CosmeticFilter implements IFilter {
           fastStartsWithFrom(line, 'matches-css', indexAfterColon) ||
           fastStartsWithFrom(line, 'matches-css-after', indexAfterColon) ||
           fastStartsWithFrom(line, 'matches-css-before', indexAfterColon) ||
-          fastStartsWithFrom(line, 'not', indexAfterColon) ||
           fastStartsWithFrom(line, 'properties', indexAfterColon) ||
           fastStartsWithFrom(line, 'subject', indexAfterColon) ||
           fastStartsWithFrom(line, 'xpath', indexAfterColon)


### PR DESCRIPTION
Cosmetic rules using the `:not()` pseudoclass selector are valid CSS, supported by all major browsers. Currently, they are ignored when parsing filter lists.

Reference: https://developer.mozilla.org/en-US/docs/Web/CSS/:not