### PR TITLE
allow the 'not' pseudoclass in cosmetic filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *not released yet*
 
+  * allow the 'not' pseudoclass in cosmetic filters [#184](https://github.com/cliqz-oss/adblocker/pull/184)
   * switch from `tldts` to `tldts-experimental` package [#183](https://github.com/cliqz-oss/adblocker/pull/183)
     * add `bootstrap` to root package.json
     * switch from `tldts` to `tldts-experimental` (faster, smaller bundles)

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -398,7 +398,6 @@ export default class CosmeticFilter implements IFilter {
           fastStartsWithFrom(line, 'matches-css', indexAfterColon) ||
           fastStartsWithFrom(line, 'matches-css-after', indexAfterColon) ||
           fastStartsWithFrom(line, 'matches-css-before', indexAfterColon) ||
-          fastStartsWithFrom(line, 'not', indexAfterColon) ||
           fastStartsWithFrom(line, 'properties', indexAfterColon) ||
           fastStartsWithFrom(line, 'subject', indexAfterColon) ||
           fastStartsWithFrom(line, 'xpath', indexAfterColon)


### PR DESCRIPTION
@antonok-edm I've cherry-picked your commit from #182 on top of the recent re-architecturing of the repository to solve conflict.