### PR TITLE
Release v0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,11 @@
 node_modules/
 
-packages/*/build/
 packages/*/dist/
 packages/*/node_modules/
 packages/*/coverage/
-packages/*/yarn.lock
-packages/*/package-lock.json
+packages/adblocker-benchmarks/requests.json
 
 bench/dataset/chromedriver
 bench/dataset/ext.zip
 bench/dataset/requests.json
 bench/.bench.json
-
-example/background.bundle.js
-example/background.js
-example/content-script.bundle.js
-example/content-script.js
-example/background.iife.js
-example/content-script.iife.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 
 ## Next
 
-*not released yet*
+## 0.12.0
 
+*2019-07-24*
+
+  * speed-up building and unify configurations [#212](https://github.com/cliqz-oss/adblocker/pull/212)
+    * switch typescript config into `composite` mode to allow faster re-builds and references between projects
+    * store all build artifacts in `dist` instead of splitting them into `dist` + `build`
+    * only emit `es6` modules with TypeScript and produce everything else with rollup (`cjs` + minimized UMD)
+    * only provide one minimized bundle: `UMD`
+    * remove `browser` key from package.json (not needed as code is cross-platform)
+    * add command to watch for changes
+  * add `ElectronBlocker` abstraction to perform adblocking in Electron [#180](https://github.com/cliqz-oss/adblocker/pull/180)
   * allow the 'not' pseudoclass in cosmetic filters [#184](https://github.com/cliqz-oss/adblocker/pull/184)
   * switch from `tldts` to `tldts-experimental` package [#183](https://github.com/cliqz-oss/adblocker/pull/183)
     * add `bootstrap` to root package.json

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ To publish a new version:
 
 0. Bump `ENGINE_VERSION` in `engine.ts` (to invalidate serialized versions)
 1. Create a new branch (e.g.: `release-x.y.z`)
-2. Update `version` in [package.json](./package.json)
+2. Update `version` using lerna: `npx lerna version --no-push --no-changelog --no-git-tag-version x.y.z`
 3. Update [CHANGELOG.md](./CHANGELOG.md)
 4. Create a release commit (e.g.: "Release vx.y.z")
 5. Create a PR for the release
 6. Merge and create a new Release on GitHub
-7. Travis takes care of the rest!
+7. Publish changes: `npx lerna publish from-package`
 
 ## License
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.12.1-alpha.3"
+  "version": "0.12.0"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Content blockers benchmark",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1-alpha.3",
+    "@cliqz/adblocker": "^0.12.0",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   }

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -38,6 +38,6 @@
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1-alpha.3"
+    "@cliqz/adblocker": "^0.12.0"
   }
 }

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -22,7 +22,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-electron": "^0.12.1-alpha.3",
+    "@cliqz/adblocker-electron": "^0.12.0",
     "axios": "^0.19.0",
     "electron": "^5.0.7",
     "ts-node": "^8.3.0",

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "private": true,
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker Electron wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -13,6 +12,9 @@
     "LICENSE",
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:cliqz-oss/adblocker.git"
@@ -33,13 +35,14 @@
     "electron": "^5.0.7"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1-alpha.3",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1-alpha.3"
+    "@cliqz/adblocker": "^0.12.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.12.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.16.4",
     "rollup-plugin-node-resolve": "^5.2.0"
-  }
+  },
+  "gitHead": "e442600bc70b58f8f1706fb517a2692e89322e61"
 }

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -22,7 +22,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^0.12.1-alpha.3",
+    "@cliqz/adblocker-puppeteer": "^0.12.0",
     "axios": "^0.19.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0",

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,7 +35,7 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1-alpha.3",
+    "@cliqz/adblocker": "^0.12.0",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -43,6 +43,6 @@
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1-alpha.3"
+    "@cliqz/adblocker": "^0.12.0"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^0.12.1-alpha.3",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1-alpha.3"
+    "@cliqz/adblocker-webextension": "^0.12.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.12.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.3",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -43,8 +43,8 @@
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1-alpha.3",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1-alpha.3",
+    "@cliqz/adblocker": "^0.12.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.12.0",
     "tldts-experimental": "^5.3.0"
   }
 }

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.12.1-alpha.3",
+  "version": "0.12.0",
   "description": "Cliqz adblocker library",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -16,7 +16,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 29;
+export const ENGINE_VERSION = 30;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
  * speed-up building and unify configurations [#212](https://github.com/cliqz-oss/adblocker/pull/212)
    * switch typescript config into `composite` mode to allow faster re-builds and references between projects
    * store all build artifacts in `dist` instead of splitting them into `dist` + `build`
    * only emit `es6` modules with TypeScript and produce everything else with rollup (`cjs` + minimized UMD)
    * only provide one minimized bundle: `UMD`
    * remove `browser` key from package.json (not needed as code is cross-platform)
    * add command to watch for changes
  * add `ElectronBlocker` abstraction to perform adblocking in Electron [#180](https://github.com/cliqz-oss/adblocker/pull/180)
  * allow the 'not' pseudoclass in cosmetic filters [#184](https://github.com/cliqz-oss/adblocker/pull/184)
  * switch from `tldts` to `tldts-experimental` package [#183](https://github.com/cliqz-oss/adblocker/pull/183)
    * add `bootstrap` to root package.json
    * switch from `tldts` to `tldts-experimental` (faster, smaller bundles)
    * switch internal commands from `npm` to `yarn`
    * remove redundant `lint` during CI
  * change structure of the cliqz/adblocker project into a monorepo [#181](https://github.com/cliqz-oss/adblocker/pull/181)
    * embrace `lerna` and `yarn` workspaces as a way to manage multiple packages
    * adopt conventional commits as a way to structure contributions
    * create few single-purpose packages:
      - `@cliqz/adblocker` (contains most building blocks)
      - `@cliqz/adblocker-circumvention` (standalone counter measures for IL)
      - `@cliqz/adblocker-webextension` (WebExtension wrapper)
      - `@cliqz/adblocker-webextension-cosmetics` (WebExtension cosmetics support)
      - `@cliqz/adblocker-puppeteer` (Puppeteer wrapper)
      - `@cliqz/adblocker-electron` (Electron wrapper)
    * create a few demonstration projects for documentation purposes:
      - `@cliqz/adblocker-webextension-example`
      - `@cliqz/adblocker-puppeteer-example`
      - `@cliqz/adblocker-electron-example`
    * migrate content blockers benchmark into `@cliqz/adblocker-benchmarks`
    * add `licenser.js` linter to enforce consistency in licenses and copyright notices
    * add `lerna-lint.js` linter to enforce consistency between all sub-packages
