### PR TITLE
allow correct size allocation for data views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,22 @@
 
 *not released*
 
+  * allow correct size allocation for data views [#257](https://github.com/cliqz-oss/adblocker/pull/257)
+
+    > Implement a mechanism which allows to predict the number of
+    > bytes needed to serialize any of the data-structures used by the
+    > adblocker, ahead of time (before serialization). This allows to lift
+    > the limitation of size completely (beforehand, we had to allocate
+    > a safe amount of memory to be sure there would be enough space).
+    > As a benefit, only the required amount of memory is used during
+    > initialization and updates, and there is no longer an arbitrary and
+    > hard-coded upper limit.
+
 ## 0.12.1
 
 *2019-08-13*
 
-  *  Update assets + re-generate compression codebooks [#256](https://github.com/cliqz-oss/adblocker/pull/256)
+  * Update assets + re-generate compression codebooks [#256](https://github.com/cliqz-oss/adblocker/pull/256)
   * implement simple event emitter for `FiltersEngine` and sub-classes [#251](https://github.com/cliqz-oss/adblocker/pull/251)
   * electron: fix bundles [#249](https://github.com/cliqz-oss/adblocker/pull/249)
   * electron: promote mutationObserver option to main config + fix constructor and parse methods [#248](https://github.com/cliqz-oss/adblocker/pull/248)

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
+    "axios": "^0.19.0",
     "benchmark": "^2.1.4",
     "chalk": "^2.4.2",
     "eslint": "^5.16.0",

--- a/packages/adblocker/jest.config.js
+++ b/packages/adblocker/jest.config.js
@@ -10,5 +10,5 @@ const baseConfig = require('../../jest.config.js');
 
 module.exports = {
   ...baseConfig,
-  collectCoverageFrom: ['./src/*', './adblocker.ts'],
+  collectCoverageFrom: ['./src/**/*.ts', './adblocker.ts'],
 };

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -51,6 +51,6 @@
   "dependencies": {
     "tldts-experimental": "^5.3.0",
     "tslib": "^1.10.0",
-    "tsmaz": "^1.2.2"
+    "tsmaz": "^1.3.0"
   }
 }

--- a/packages/adblocker/src/compression.ts
+++ b/packages/adblocker/src/compression.ts
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { factory } from 'tsmaz';
+import { Smaz } from 'tsmaz';
 
 import cosmeticSelectorCodebook from './codebooks/cosmetic-selector';
 import networkCSPCodebook from './codebooks/network-csp';
@@ -14,45 +14,10 @@ import networkFilterCodebook from './codebooks/network-filter';
 import networkHostnameCodebook from './codebooks/network-hostname';
 import networkRedirectCodebook from './codebooks/network-redirect';
 
-type inflate = (_: Uint8Array) => string;
-type deflate = (_: string) => Uint8Array;
-
 export default class Compression {
-  public deflateCosmeticString: deflate;
-  public deflateNetworkFilterString: deflate;
-  public deflateNetworkCSPString: deflate;
-  public deflateNetworkRedirectString: deflate;
-  public deflateNetworkHostnameString: deflate;
-  public inflateCosmeticString: inflate;
-  public inflateNetworkFilterString: inflate;
-  public inflateNetworkCSPString: inflate;
-  public inflateNetworkRedirectString: inflate;
-  public inflateNetworkHostnameString: inflate;
-
-  constructor() {
-    // Cosmetic selectors
-    const cosmeticSmaz = factory(cosmeticSelectorCodebook);
-    this.deflateCosmeticString = cosmeticSmaz[0];
-    this.inflateCosmeticString = cosmeticSmaz[1];
-
-    // Network CSPs
-    const networkCSPSmaz = factory(networkCSPCodebook);
-    this.deflateNetworkCSPString = networkCSPSmaz[0];
-    this.inflateNetworkCSPString = networkCSPSmaz[1];
-
-    // Network redirects
-    const networkRedirectSmaz = factory(networkRedirectCodebook);
-    this.deflateNetworkRedirectString = networkRedirectSmaz[0];
-    this.inflateNetworkRedirectString = networkRedirectSmaz[1];
-
-    // Network hostnames
-    const networkHostnameSmaz = factory(networkHostnameCodebook);
-    this.deflateNetworkHostnameString = networkHostnameSmaz[0];
-    this.inflateNetworkHostnameString = networkHostnameSmaz[1];
-
-    // Network filters
-    const networkFilterSmaz = factory(networkFilterCodebook);
-    this.deflateNetworkFilterString = networkFilterSmaz[0];
-    this.inflateNetworkFilterString = networkFilterSmaz[1];
-  }
+  public readonly cosmeticSelector: Smaz = new Smaz(cosmeticSelectorCodebook);
+  public readonly networkCSP: Smaz = new Smaz(networkCSPCodebook);
+  public readonly networkRedirect: Smaz = new Smaz(networkRedirectCodebook);
+  public readonly networkHostname: Smaz = new Smaz(networkHostnameCodebook);
+  public readonly networkFilter: Smaz = new Smaz(networkFilterCodebook);
 }

--- a/packages/adblocker/src/config.ts
+++ b/packages/adblocker/src/config.ts
@@ -52,6 +52,8 @@ export default class Config {
   }
 
   public getSerializedSize(): number {
+    // NOTE: this should always be the number of attributes and needs to be
+    // updated when `Config` changes.
     return 8 * StaticDataView.sizeOfBool();
   }
 

--- a/packages/adblocker/src/config.ts
+++ b/packages/adblocker/src/config.ts
@@ -51,6 +51,10 @@ export default class Config {
     this.loadNetworkFilters = loadNetworkFilters;
   }
 
+  public getSerializedSize(): number {
+    return 8 * StaticDataView.sizeOfBool();
+  }
+
   public serialize(buffer: StaticDataView): void {
     buffer.pushBool(this.debug);
     buffer.pushBool(this.enableCompression);

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -301,6 +301,17 @@ export default class CosmeticFilterBucket {
     this.hrefsIndex.update(hrefSelectors, removedFilters);
   }
 
+  public getSerializedSize(): number {
+    return (
+      this.genericRules.getSerializedSize() +
+      this.unhideIndex.getSerializedSize() +
+      this.hostnameIndex.getSerializedSize() +
+      this.classesIndex.getSerializedSize() +
+      this.idsIndex.getSerializedSize() +
+      this.hrefsIndex.getSerializedSize()
+    );
+  }
+
   public serialize(buffer: StaticDataView): void {
     this.genericRules.serialize(buffer);
     this.unhideIndex.serialize(buffer);

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -303,12 +303,12 @@ export default class CosmeticFilterBucket {
 
   public getSerializedSize(): number {
     return (
-      this.genericRules.getSerializedSize() +
-      this.unhideIndex.getSerializedSize() +
-      this.hostnameIndex.getSerializedSize() +
       this.classesIndex.getSerializedSize() +
+      this.genericRules.getSerializedSize() +
+      this.hostnameIndex.getSerializedSize() +
+      this.hrefsIndex.getSerializedSize() +
       this.idsIndex.getSerializedSize() +
-      this.hrefsIndex.getSerializedSize()
+      this.unhideIndex.getSerializedSize()
     );
   }
 

--- a/packages/adblocker/src/engine/bucket/filters.ts
+++ b/packages/adblocker/src/engine/bucket/filters.ts
@@ -67,6 +67,7 @@ export default class FiltersContainer<T extends IFilter> {
     // removed/added filters.
     let bufferSizeEstimation: number = this.filters.byteLength;
     let selected: T[] = [];
+    const compression = this.config.enableCompression;
 
     // Add existing rules (removing the ones with ids in `removedFilters`)
     const currentFilters = this.getFilters();
@@ -84,7 +85,7 @@ export default class FiltersContainer<T extends IFilter> {
           if (removedFilters.has(filter.getId()) === false) {
             selected.push(filter);
           } else {
-            bufferSizeEstimation -= filter.getSerializedSize();
+            bufferSizeEstimation -= filter.getSerializedSize(compression);
           }
         }
       }
@@ -97,7 +98,7 @@ export default class FiltersContainer<T extends IFilter> {
     const numberOfExistingFilters: number = selected.length;
     for (let i = 0; i < newFilters.length; i += 1) {
       const filter = newFilters[i];
-      bufferSizeEstimation += filter.getSerializedSize();
+      bufferSizeEstimation += filter.getSerializedSize(compression);
       selected.push(filter);
     }
 

--- a/packages/adblocker/src/engine/bucket/filters.ts
+++ b/packages/adblocker/src/engine/bucket/filters.ts
@@ -129,6 +129,10 @@ export default class FiltersContainer<T extends IFilter> {
     }
   }
 
+  public getSerializedSize(): number {
+    return StaticDataView.sizeOfBytes(this.filters, false /* no alignement */);
+  }
+
   public serialize(buffer: StaticDataView): void {
     buffer.pushBytes(this.filters);
   }

--- a/packages/adblocker/src/engine/bucket/network.ts
+++ b/packages/adblocker/src/engine/bucket/network.ts
@@ -90,6 +90,13 @@ export default class NetworkFilterBucket {
     this.badFiltersIds = null;
   }
 
+  public getSerializedSize(): number {
+    return (
+      this.index.getSerializedSize() +
+      this.badFilters.getSerializedSize()
+    );
+  }
+
   public serialize(buffer: StaticDataView): void {
     this.index.serialize(buffer);
     this.badFilters.serialize(buffer);

--- a/packages/adblocker/src/engine/bucket/network.ts
+++ b/packages/adblocker/src/engine/bucket/network.ts
@@ -92,8 +92,8 @@ export default class NetworkFilterBucket {
 
   public getSerializedSize(): number {
     return (
-      this.index.getSerializedSize() +
-      this.badFilters.getSerializedSize()
+      this.badFilters.getSerializedSize() +
+      this.index.getSerializedSize()
     );
   }
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -17,7 +17,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 32;
+export const ENGINE_VERSION = 33;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -108,10 +108,11 @@ export default class FilterEngine extends EventEmitter<
     engine.lists = lists;
 
     // Deserialize buckets
-    engine.filters = NetworkFilterBucket.deserialize(buffer, config);
-    engine.exceptions = NetworkFilterBucket.deserialize(buffer, config);
     engine.importants = NetworkFilterBucket.deserialize(buffer, config);
     engine.redirects = NetworkFilterBucket.deserialize(buffer, config);
+    engine.filters = NetworkFilterBucket.deserialize(buffer, config);
+    engine.exceptions = NetworkFilterBucket.deserialize(buffer, config);
+
     engine.csp = NetworkFilterBucket.deserialize(buffer, config);
     engine.genericHides = NetworkFilterBucket.deserialize(buffer, config);
     engine.cosmetics = CosmeticFilterBucket.deserialize(buffer, config);
@@ -246,10 +247,11 @@ export default class FilterEngine extends EventEmitter<
     }
 
     // Filters buckets
-    this.filters.serialize(buffer);
-    this.exceptions.serialize(buffer);
     this.importants.serialize(buffer);
     this.redirects.serialize(buffer);
+    this.filters.serialize(buffer);
+    this.exceptions.serialize(buffer);
+
     this.csp.serialize(buffer);
     this.genericHides.serialize(buffer);
     this.cosmetics.serialize(buffer);
@@ -362,11 +364,11 @@ export default class FilterEngine extends EventEmitter<
         removedNetworkFilters.length === 0 ? undefined : new Set(removedNetworkFilters);
 
       // Update buckets in-place
-      this.filters.update(filters, removedNetworkFiltersSet);
-      this.csp.update(csp, removedNetworkFiltersSet);
-      this.exceptions.update(exceptions, removedNetworkFiltersSet);
       this.importants.update(importants, removedNetworkFiltersSet);
       this.redirects.update(redirects, removedNetworkFiltersSet);
+      this.filters.update(filters, removedNetworkFiltersSet);
+      this.exceptions.update(exceptions, removedNetworkFiltersSet);
+      this.csp.update(csp, removedNetworkFiltersSet);
       this.genericHides.update(genericHides, removedNetworkFiltersSet);
     }
 

--- a/packages/adblocker/src/engine/reverse-index.ts
+++ b/packages/adblocker/src/engine/reverse-index.ts
@@ -70,12 +70,12 @@ const EMPTY_BUCKET: number = Number.MAX_SAFE_INTEGER >>> 0;
 
 /**
  * The ReverseIndex is an accelerating data structure which allows finding a
- * subset of the filters given a list of token seen in a URL. It is the core of
- * the adblocker's matching capabilities.
+ * subset of the filters given a list of tokens seen in a URL. It is the core
+ * of the adblocker's matching capabilities and speed.
  *
  * It has mainly two caracteristics:
- * 1. It should be very compact and be able to load fast.
- * 2. It should be *very fast* in finding potential candidates.
+ * 1. It is very compact and is able to load fast.
+ * 2. It is *very fast* in finding potential candidates.
  *
  * Conceptually, the reverse index dispatches filters in "buckets" (an array of
  * one or more filters). Filters living in the same bucket are guaranteed to
@@ -107,10 +107,10 @@ const EMPTY_BUCKET: number = Number.MAX_SAFE_INTEGER >>> 0;
  * =========================================
  *
  * Each filter is only indexed *once*, which means that we need to pick one of
- * the tokens appearing in the pattern. We choose the token such has each filter
- * is indexed using the token which was the *least seen* globally. In other
- * words, we pick the most discriminative token for each filter. This is done
- * using the following algorithm:
+ * the tokens appearing in the pattern. We choose the token such that each
+ * filter is indexed using the token which was the *least seen* globally. In
+ * other words, we pick the most discriminative token for each filter. This is
+ * done using the following algorithm:
  *   1. Tokenize all the filters which will be stored in the index
  *   2. Compute a histogram of frequency of each token (globally)
  *   3. Select the best token for each filter (lowest frequency)
@@ -150,36 +150,41 @@ export default class ReverseIndex<T extends IFilter> {
     });
   }
 
-  // Internal. Compact representation of the reverse index. It contains three distinct parts:
+  // Internal, compact representation of the reverse index. It contains three
+  // distinct parts stored in the same typed array:
   //
-  // 1. The list of all filters contained in this index, serialized
-  // contiguously (one after the other) in the typed array starting at index
-  // 0. This would look like: |f1|f2|f3|...|fn| Note that not all filters use
-  // the same amount of memory (or number of bytes) so the only way to
-  // navigate the compact representation at this point is to iterate through
-  // all of them from first to last. Which is why we need a small "index" to
-  // help us navigate this compact representation and leads us to the second
-  // section of `this.view`.
+  // 1. "tokens lookup index" allows to identify a sub-set of buckets which
+  // likely contain filters for a given token. It is an approximate dispatch
+  // table which maps a mask of N bits (N being smaller than 31 bits, the size
+  // of a token) to a list of buckets having a 'token' sharing these same N
+  // bits sub-set. If the binary representation of the token for bucket1 is
+  // 101010 and suffix has size 3, then we would lookup the "tokens lookup
+  // index" using the last 3 bits "010" which would give us the offset in our
+  // typed array where we can start reading the filters of buckets having a
+  // token ending with the same 3 bits. The value of N is always a power of 2
+  // depending on the total number of filters stored in the index; determined
+  // at the time `update(...)` is called.
   //
-  // 2. buckets index which conceptually can be understood as a way to group
-  // several buckets in the same neighborhood of the typed array. It could
-  // look something like: |bucket1|bucket2|bucket3|...| each bucket could
-  // contain multiple filters. In reality, for each section of this bucket
-  // index, we know how many filters there are and the filters for multiple
-  // buckets are interleaved. For example if the index starts with a section
-  // containing |bucket1|bucket2|bucket3| and these bucket have tokens `tok1`,
-  // `tok2` and `tok3` respectively, then the final representation in memory
-  // could be: |tok1|f1|tok2|f2|tok1|f3|tok3|f4|tok2|f5| (where `f1`, `f2`,
-  // etc. are indices to the serialized representation of each filter, in the
-  // same array, described in 1. above).
+  // 2. "buckets index" is an array which associates tokens to filters. The
+  // structure is: token, filter, token, filter, etc. To identify all the
+  // filters indexed with 'token' a naive approach would be to iterate on
+  // "buckets index" and collect all the filters indexed with 'token'. This
+  // would be *very inefficient*! To make this process faster, filters in
+  // "buckets index" are grouped so that buckets sharing the same suffix of N
+  // bits in their indexing token (see "tokens lookup index") are stored side
+  // by side in the typed array. To know where this section start given a
+  // particular token, we use "tokens lookup index" which associated the suffix
+  // of size N to an index in "buckets index". From there we can iterate on the
+  // candidates.
   //
-  // 3. The last part is called "tokens lookup index" and allows to locate the
-  // bucket given a suffix of the indexing token. If the binary representation
-  // of the token for bucket1 is 101010 and prefix has size 3, then we would
-  // lookup the "tokens lookup index" using the last 3 bits "010" which would
-  // give us the offset in our typed array where we can start reading the
-  // filters of buckets having a token ending with the same 3 bits.
-  // Optionaly initialize the index with given filters.
+  // 3. "filters index" contains the filters themselves. "buckets index"
+  // presented earlier does not contain filters, but an index to the "filters
+  // index". This allows a filter to be indexed multiple times without
+  // introducing any overhead; the filter can be associated with multiple
+  // tokens in "buckets index" (each pointing to the same place in "filters
+  // index") but its actual representation is stored only once in "filters
+  // index".
+
   private bucketsIndex: Uint32Array = EMPTY_UINT32_ARRAY;
   private filtersIndexStart: number = 0;
   private numberOfFilters: number = 0;
@@ -188,19 +193,25 @@ export default class ReverseIndex<T extends IFilter> {
 
   // In-memory cache used to keep track of buckets which have been loaded from
   // the compact representation (i.e.: this.view). It is not strictly necessary
-  // but will speed-up retrival of popular filters.
+  // but will speed-up retrival of popular filters (since we do not have to
+  // perform the lookup in "tokens index" and "buckets index" everytime).
   private readonly cache: Map<number, Bucket<T>> = new Map();
 
-  // Because this index can store different kinds of filters (e.g. NetworkFilter
-  // and CosmeticFilter) we need to specify a function used to load them back
-  // from their serialization form at matching time. This function takes a data
-  // view with `pos` at the righ offset (start of a filter) and returns an
-  // instance of the filter itself which will be used for matching.
+  // Function used to load a filter (e.g.: CosmeticFilter or NetworkFilter)
+  // from its compact representation in the "filters index" section of the
+  // typed array. Each filter exposes a `serialize(...)` method which is used
+  // to store it in `this.view` (section "filters index"). While matching we
+  // need to retrieve the instance of the filter to perform matching and use
+  // `this.deserializeFilter(...)` to do so.
   private readonly deserializeFilter: (view: StaticDataView) => T;
 
-  // Optionally, filters in a given bucket can be "optimized" when loaded in
-  // memory from the view. Optimizations aim at making sub-sequent matching more
-  // efficient; for example by reducing the number of filters.
+  // Optional function which will be used to optimize a list of filters
+  // in-memory. Typically this is used while matching when a list of filters is
+  // loaded in memory and stored in `this.cache`. Before using the bucket, we
+  // call `this.optimize(...)` on the list of filters to allow some
+  // optimizations to be performed (e.g.: fusion of similar filters, etc.).
+  // Have a look into `./src/engine/optimizer.ts` for examples of such
+  // optimizations.
   private readonly optimize: (filters: T[]) => T[];
   private readonly config: Readonly<Config>;
 
@@ -216,20 +227,7 @@ export default class ReverseIndex<T extends IFilter> {
     config: Config;
   }) {
     this.view = StaticDataView.empty(config);
-
-    // Function used to load a filter (e.g.: CosmeticFilter or NetworkFilter)
-    // from its compact representation. Each filter exposes a `serialize` method
-    // which is used to store it in `this.view`. While matching we need to
-    // retrieve the instance of the filter to perform matching and use
-    // `this.deserializeFilter` to do so.
     this.deserializeFilter = deserialize;
-
-    // Optional function which will be used to optimize a list of filters
-    // in-memory. Typically this is used while matching when a list of filters
-    // are loaded in memory and stored in `this.cache`. Before using the bucket,
-    // we can `this.optimize` on the list of filters to allow some optimizations
-    // to be performed (e.g.: fusion of similar filters, etc.). Have a look into
-    // `./src/engine/optimizer.ts` for examples of such optimizations.
     this.optimize = optimize;
     this.config = config;
 
@@ -239,8 +237,9 @@ export default class ReverseIndex<T extends IFilter> {
   }
 
   /**
-   * Load all filters from this index in memory (i.e.: deserialize them from the
-   * byte array into NetworkFilter or CosmeticFilter instances).
+   * Load all filters from this index in memory (i.e.: deserialize them from
+   * the byte array into NetworkFilter or CosmeticFilter instances). This is
+   * mostly useful for debugging or testing purposes.
    */
   public getFilters(): T[] {
     const filters: T[] = [];
@@ -249,7 +248,7 @@ export default class ReverseIndex<T extends IFilter> {
       return filters;
     }
 
-    // set view cursor at the start of filters index
+    // set view cursor at the start of "filters index"
     this.view.setPos(this.filtersIndexStart);
 
     for (let i = 0; i < this.numberOfFilters; i += 1) {
@@ -260,7 +259,7 @@ export default class ReverseIndex<T extends IFilter> {
   }
 
   /**
-   * Return an array of all the tokens currently used as keys of the index.
+   * Return an array of all the tokens currently used as keys of the "buckets index".
    */
   public getTokens(): Uint32Array {
     const tokens: Set<number> = new Set();
@@ -272,6 +271,9 @@ export default class ReverseIndex<T extends IFilter> {
     return new Uint32Array(tokens);
   }
 
+  /**
+   * Estimate the number of bytes needed to serialize this instance of `ReverseIndex`.
+   */
   public getSerializedSize(): number {
     // 12 = 4 bytes (tokensLookupIndex.length) + 4 bytes (bucketsIndex.length) + 4 bytes (numberOfFilters)
     return 12 + StaticDataView.sizeOfBytes(this.view.buffer, true /* align */);
@@ -322,9 +324,12 @@ export default class ReverseIndex<T extends IFilter> {
    * which need to be removed from the index.
    */
   public update(newFilters: T[], removedFilters: Set<number> | undefined): void {
-    const compression = this.config.enableCompression;
-    this.cache.clear();
+    // Reset internal cache on each update
+    if (this.cache.size !== 0) {
+      this.cache.clear();
+    }
 
+    const compression = this.config.enableCompression;
     let totalNumberOfTokens = 0;
     let totalNumberOfIndexedFilters = 0;
     const filtersTokens: Array<{ filter: T; multiTokens: Uint32Array[] }> = [];
@@ -334,74 +339,50 @@ export default class ReverseIndex<T extends IFilter> {
     // the number of indexed filters, multiplied by 2 (since we store both the
     // token a filter is indexed with and the index of the filter).
     let bucketsIndexSize = 0;
+
+    // Re-use the current size of "filters index" as a starting point so that
+    // we only need to update with new or removed filters. This saves time if
+    // we perform a small update on an existing index.
     let estimatedBufferSize = this.view.buffer.byteLength - this.filtersIndexStart;
 
-    // Compute tokens for all filters (the ones already contained in the index
-    // *plus* the new ones *minus* the ones removed).
-    const existingFilters = this.getFilters();
-    const shouldCheckRemovedFilters: boolean = (
-      existingFilters.length !== 0 &&
-      removedFilters !== undefined &&
-      removedFilters.size !== 0
-    );
-
-    // Update estimated view size with new filters
-    for (let i = 0; i < newFilters.length; i += 1) {
-      estimatedBufferSize += newFilters[i].getSerializedSize(compression);
-    }
-
-    let filters = existingFilters;
-    if (filters.length === 0) {
-      // If the reverse index is currently empty, then `filters` is simply `newFilters`
-      filters = newFilters;
-    } else {
-      for (let i = 0; i < newFilters.length; i += 1) {
-        filters.push(newFilters[i]);
-      }
-    }
-
-    // When we run in `debug` mode, we enable fully deterministic updates of
-    // internal data-structure. To this effect, we sort all filters before
-    // insertion.
-    if (this.config.debug === true) {
-      filters.sort((f1: T, f2: T): number => f1.getId() - f2.getId());
-    }
-
-    for (let i = 0; i < filters.length; i += 1) {
-      const filter = filters[i];
-      if (
-        shouldCheckRemovedFilters === false ||
-        (removedFilters !== undefined && removedFilters.has(filter.getId()) === false)
-      ) {
-        // Tokenize filter
-        const multiTokens = filter.getTokens();
-        filtersTokens.push({
-          filter,
-          multiTokens,
-        });
-
-        for (let j = 0; j < multiTokens.length; j += 1) {
-          bucketsIndexSize += 2; // token + filter index
-
-          // Update tokens histogram
-          const tokens = multiTokens[j];
-          totalNumberOfIndexedFilters += 1;
-          totalNumberOfTokens += tokens.length;
-          for (let k = 0; k < tokens.length; k += 1) {
-            histogram.incr(tokens[k]);
+    // Create a list of all filters which will be part of the index. This means
+    // loading existing filters, removing the ones that need to be deleted and
+    // adding the new ones.  At the same time, we update the estimation of
+    // buffer size needed to store this index.
+    let filters: T[] = this.getFilters();
+    if (filters.length !== 0) {
+      // If there is at least one existing filter, then we check if some should
+      // be removed. We subtract their size from the total estimated buffer
+      // size.
+      if (removedFilters !== undefined && removedFilters.size !== 0) {
+        filters = filters.filter((f) => {
+          if (removedFilters.has(f.getId())) {
+            estimatedBufferSize -= f.getSerializedSize(compression);
+            return false;
           }
-        }
-      } else {
-        // Filter was removed so we just remove its size from total needed size
-        estimatedBufferSize -= filter.getSerializedSize(compression);
+
+          return true;
+        });
+      }
+
+      // Add new filters to the list and also update estimated size
+      for (let i = 0; i < newFilters.length; i += 1) {
+        const filter = newFilters[i];
+        estimatedBufferSize += filter.getSerializedSize(compression);
+        filters.push(filter);
+      }
+    } else {
+      // In the case where there is no existing filter in the index (happens on
+      // initialization), then we can take a fast-path and not check removed
+      // filters at all. There is also no need to copy the array of filters.
+      filters = newFilters;
+      for (let i = 0; i < newFilters.length; i += 1) {
+        estimatedBufferSize += newFilters[i].getSerializedSize(compression);
       }
     }
 
-    // Add size of bucketsIndex to total size (* 4 because these are 32 bits numbers)
-    estimatedBufferSize += bucketsIndexSize * 4;
-
-    // No filters given; reset to empty bucket
-    if (filtersTokens.length === 0) {
+    // No filters given; reset to empty index and abort.
+    if (filters.length === 0) {
       this.updateInternals({
         bucketsIndex: EMPTY_UINT32_ARRAY,
         filtersIndexStart: 0,
@@ -412,6 +393,46 @@ export default class ReverseIndex<T extends IFilter> {
       return;
     }
 
+    // When we run in `debug` mode, we enable fully deterministic updates of
+    // internal data-structure. To this effect, we sort all filters before
+    // insertion.
+    if (this.config.debug === true) {
+      filters.sort((f1: T, f2: T): number => f1.getId() - f2.getId());
+    }
+
+    // Tokenize all filters stored in this index. And compute a histogram of
+    // tokens so that we can decide how to index each filter efficiently.
+    for (let i = 0; i < filters.length; i += 1) {
+      const filter = filters[i];
+
+      // Tokenize `filter` and store the result in `filtersTokens` which will
+      // be used in the next step to select the best token for each filter.
+      const multiTokens = filter.getTokens();
+      filtersTokens.push({
+        filter,
+        multiTokens,
+      });
+
+      // Update estimated size of "buckets index" based on number of times this
+      // particular filter will be indexed.
+      bucketsIndexSize += 2 * multiTokens.length; // token + filter index
+      totalNumberOfIndexedFilters += multiTokens.length;
+
+      // Each filter can be indexed more than once, so `getTokens(...)` returns
+      // multiple sets of tokens. We iterate on all of them and update the
+      // histogram for each.
+      for (let j = 0; j < multiTokens.length; j += 1) {
+        const tokens = multiTokens[j];
+        totalNumberOfTokens += tokens.length;
+        for (let k = 0; k < tokens.length; k += 1) {
+          histogram.incr(tokens[k]);
+        }
+      }
+    }
+
+    // Add size of bucketsIndex to total size (x4 because these are 32 bits numbers)
+    estimatedBufferSize += bucketsIndexSize * 4;
+
     // Add an heavy weight on these common patterns because they appear in
     // almost all URLs. If there is a choice, then filters should use other
     // tokens than those.
@@ -421,44 +442,36 @@ export default class ReverseIndex<T extends IFilter> {
     histogram.set(fastHash('com'), totalNumberOfTokens);
     // TODO - consider adding more of these, check on requests dataset
 
-    // Prepare `tokensLookupIndex`. This is an array where keys are suffixes of
-    // N bits from tokens (the ones used to index filters in the index) and
-    // values are indices to compact representation of buckets. Each bucket
-    // contains a list of filters associated with a token with identical N bits
-    // suffix. This allows to quickly identify the potential filters given a
-    // query token.
+    // Prepare "tokens index" (see documentation in constructor of `ReverseIndex` class above).
     const tokensLookupIndexSize: number = Math.max(2, nextPow2(totalNumberOfIndexedFilters));
     const mask: number = tokensLookupIndexSize - 1;
-    const prefixes: Array<Array<{ token: number; index: number }>> = [];
+    const suffixes: Array<Array<[number, number]>> = [];
     for (let i = 0; i < tokensLookupIndexSize; i += 1) {
-      prefixes.push([]);
+      suffixes.push([]);
     }
 
-    // Add size of tokensLookupIndex to total size
+    // Add size of tokensLookupIndex to total size (x4 because these are 32 bits numbers)
     estimatedBufferSize += tokensLookupIndexSize * 4;
 
-    // This byte array contains all the filters serialized consecutively.
-    // Having them separately from the reverse index structure allows filters
-    // to be indexed more than once while not paying extra storage cost.
-    // `buffer` is a contiguous chunk of memory which will be used to store 3
-    // kinds of data:
-    // 1. The first section contains all the filters stored in the index
-    // 2. The second section contains the compact buckets where filters having
-    // their indexing token sharing the last N bits are grouped together.
+    // At this point we know the number of bytes needed for the compact
+    // representation of this reverse index ("tokens index" + "buckets index" +
+    // "filters index"). We allocate it at once and proceed with populating it.
     const buffer = StaticDataView.allocate(estimatedBufferSize, this.config);
-
-    // Allocate views for tokens and buckets
     const tokensLookupIndex = buffer.getUint32ArrayView(tokensLookupIndexSize);
     const bucketsIndex = buffer.getUint32ArrayView(bucketsIndexSize);
     const filtersIndexStart = buffer.getPos();
 
-    // For each filter, find the best token (least seen)
+    // For each filter, find the best token (least seen) based on histogram.
+    // Since we are iterating again on the filters, we populate "filters index"
+    // in the same loop and keep track of their indices so that we can later
+    // populate "buckets index".
     for (let i = 0; i < filtersTokens.length; i += 1) {
       const filterTokens = filtersTokens[i];
       const filter: T = filterTokens.filter;
       const multiTokens: Uint32Array[] = filterTokens.multiTokens;
 
-      // Serialize this filter and keep track of its index in the byte array
+      // Serialize this filter and keep track of its index in the byte array;
+      // it will be used in "buckets index" to point to this filter.
       const filterIndex = buffer.pos;
       filter.serialize(buffer);
 
@@ -467,7 +480,7 @@ export default class ReverseIndex<T extends IFilter> {
         const tokens: Uint32Array = multiTokens[j];
 
         // Find best token (least seen) from `tokens` using `histogram`.
-        let bestToken: number = 0;
+        let bestToken: number = 0; // default = wildcard bucket
         let minCount: number = totalNumberOfTokens + 1;
         for (let k = 0; k < tokens.length; k += 1) {
           const tokenCount = histogram.get(tokens[k]);
@@ -476,7 +489,7 @@ export default class ReverseIndex<T extends IFilter> {
             bestToken = tokens[k];
 
             // Fast path, if the current token has only been seen once, we can
-            // stop iterating since we will not find better!
+            // stop iterating since we will not find a better alternarive!
             if (minCount === 1) {
               break;
             }
@@ -485,22 +498,18 @@ export default class ReverseIndex<T extends IFilter> {
 
         // `bestToken & mask` represents the N last bits of `bestToken`. We
         // group all filters indexed with a token sharing the same N bits.
-        prefixes[bestToken & mask].push({
-          index: filterIndex,
-          token: bestToken,
-        });
+        suffixes[bestToken & mask].push([bestToken, filterIndex]);
       }
     }
 
-    // Populate tokens and buckets indices
+    // Populate "tokens index" and "buckets index" based on best token found for each filter.
     let indexInBucketsIndex = 0;
     for (let i = 0; i < tokensLookupIndexSize; i += 1) {
-      const filtersForMask = prefixes[i];
+      const filtersForMask = suffixes[i];
       tokensLookupIndex[i] = indexInBucketsIndex;
       for (let j = 0; j < filtersForMask.length; j += 1) {
-        const { token, index } = filtersForMask[j];
-        bucketsIndex[indexInBucketsIndex++] = token;
-        bucketsIndex[indexInBucketsIndex++] = index;
+        bucketsIndex[indexInBucketsIndex++] = filtersForMask[j][0];
+        bucketsIndex[indexInBucketsIndex++] = filtersForMask[j][1];
       }
     }
 
@@ -582,16 +591,17 @@ export default class ReverseIndex<T extends IFilter> {
       // If we have filters for `token` then deserialize filters in memory and
       // create a `Bucket` instance to hold them for future access.
       const filters: T[] = [];
+      const view = this.view;
       for (let i = 0; i < filtersIndices.length; i += 1) {
-        this.view.setPos(filtersIndices[i]);
-        filters.push(this.deserializeFilter(this.view));
+        view.setPos(filtersIndices[i]);
+        filters.push(this.deserializeFilter(view));
       }
 
       // Create new bucket with found filters (only optimize if we have more
       // than one filter).
       bucket = {
         filters: filters.length > 1 ? this.optimize(filters) : filters,
-        lastRequestSeen: 0,
+        lastRequestSeen: -1, // safe because all ids are positive
       };
 
       this.cache.set(token, bucket);

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -629,13 +629,13 @@ export default class CosmeticFilter implements IFilter {
    * in a DataView. This does not need to be 100% accurate but should be an
    * upper-bound. It should also be as fast as possible.
    */
-  public getSerializedSize(): number {
+  public getSerializedSize(compression: boolean): number {
     let estimate: number = 1 + 1; // mask (1 byte) + optional parts (1 byte)
 
     if (this.isUnicode()) {
       estimate += StaticDataView.sizeOfUTF8(this.selector);
     } else {
-      estimate += StaticDataView.sizeOfASCII(this.selector);
+      estimate += StaticDataView.sizeOfCosmeticSelector(this.selector, compression);
     }
 
     if (this.entities !== undefined) {

--- a/packages/adblocker/src/filters/interface.ts
+++ b/packages/adblocker/src/filters/interface.ts
@@ -13,5 +13,5 @@ export default interface IFilter {
   getId: () => number;
   getTokens: () => Uint32Array[];
   serialize: (buffer: StaticDataView) => void;
-  getSerializedSize(): number;
+  getSerializedSize(compression: boolean): number;
 }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -838,23 +838,23 @@ export default class NetworkFilter implements IFilter {
     buffer.setByte(index, optionalParts);
   }
 
-  public getSerializedSize(): number {
+  public getSerializedSize(compression: boolean): number {
     let estimate: number = 4 + 1; // mask = 4 bytes // optional parts = 1 byte
 
     if (this.csp !== undefined) {
-      estimate += StaticDataView.sizeOfASCII(this.csp);
+      estimate += StaticDataView.sizeOfNetworkCSP(this.csp, compression);
     }
 
     if (this.filter !== undefined) {
       if (this.isUnicode()) {
         estimate += StaticDataView.sizeOfUTF8(this.filter);
       } else {
-        estimate += StaticDataView.sizeOfASCII(this.filter);
+        estimate += StaticDataView.sizeOfNetworkFilter(this.filter, compression);
       }
     }
 
     if (this.hostname !== undefined) {
-      estimate += StaticDataView.sizeOfASCII(this.hostname);
+      estimate += StaticDataView.sizeOfNetworkHostname(this.hostname, compression);
     }
 
     if (this.optDomains !== undefined) {
@@ -874,7 +874,7 @@ export default class NetworkFilter implements IFilter {
     }
 
     if (this.redirect !== undefined) {
-      estimate += StaticDataView.sizeOfASCII(this.redirect);
+      estimate += StaticDataView.sizeOfNetworkRedirect(this.redirect, compression);
     }
 
     return estimate;

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -24,7 +24,7 @@ export default class Resources {
 
     // Deserialize `resources`
     const resources: Map<string, IResource> = new Map();
-    const numberOfResources = buffer.getUint8();
+    const numberOfResources = buffer.getUint16();
     for (let i = 0; i < numberOfResources; i += 1) {
       resources.set(buffer.getASCII(), {
         contentType: buffer.getASCII(),
@@ -111,7 +111,7 @@ export default class Resources {
   public getSerializedSize(): number {
     let estimatedSize = (
       StaticDataView.sizeOfASCII(this.checksum) +
-      StaticDataView.sizeOfByte() // resources.size
+      (2 * StaticDataView.sizeOfByte()) // resources.size
     );
 
     this.resources.forEach(({ contentType, data }, name) => {
@@ -130,7 +130,7 @@ export default class Resources {
     buffer.pushASCII(this.checksum);
 
     // Serialize `resources`
-    buffer.pushUint8(this.resources.size);
+    buffer.pushUint16(this.resources.size);
     this.resources.forEach(({ contentType, data }, name) => {
       buffer.pushASCII(name);
       buffer.pushASCII(contentType);

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -108,6 +108,23 @@ export default class Resources {
     return this.resources.get(name);
   }
 
+  public getSerializedSize(): number {
+    let estimatedSize = (
+      StaticDataView.sizeOfASCII(this.checksum) +
+      StaticDataView.sizeOfByte() // resources.size
+    );
+
+    this.resources.forEach(({ contentType, data }, name) => {
+      estimatedSize += (
+        StaticDataView.sizeOfASCII(name) +
+        StaticDataView.sizeOfASCII(contentType) +
+        StaticDataView.sizeOfASCII(data)
+      );
+    });
+
+    return estimatedSize;
+  }
+
   public serialize(buffer: StaticDataView): void {
     // Serialize `checksum`
     buffer.pushASCII(this.checksum);

--- a/packages/adblocker/test/filters-size-estimation.test.ts
+++ b/packages/adblocker/test/filters-size-estimation.test.ts
@@ -15,12 +15,13 @@ import { loadAllLists } from './utils';
 
 describe('Make sure size estimate is accurate', () => {
   const { cosmeticFilters, networkFilters } = parseFilters(loadAllLists(), { debug: true });
-  const buffer = StaticDataView.allocate(1000000, { enableCompression: false });
 
-  function testSizeEstimate<T extends IFilter>(filters: T[]): void {
+  function testSizeEstimate<T extends IFilter>(filters: T[], compression: boolean): void {
+    const buffer = StaticDataView.allocate(1000000, { enableCompression: compression });
+
     for (let i = 0; i < filters.length; i += 1) {
       const filter = filters[i];
-      const estimate = filter.getSerializedSize();
+      const estimate = filter.getSerializedSize(compression);
 
       // Serialize filter
       buffer.seekZero();
@@ -36,10 +37,18 @@ describe('Make sure size estimate is accurate', () => {
   }
 
   it('network', () => {
-    testSizeEstimate<NetworkFilter>(networkFilters);
+    testSizeEstimate<NetworkFilter>(networkFilters, false);
+  });
+
+  it('network (compression)', () => {
+    testSizeEstimate<NetworkFilter>(networkFilters, true);
   });
 
   it('cosmetic', () => {
-    testSizeEstimate<CosmeticFilter>(cosmeticFilters);
+    testSizeEstimate<CosmeticFilter>(cosmeticFilters, false);
+  });
+
+  it('cosmetic (compression)', () => {
+    testSizeEstimate<CosmeticFilter>(cosmeticFilters, true);
   });
 });

--- a/packages/adblocker/test/reverse-index.test.ts
+++ b/packages/adblocker/test/reverse-index.test.ts
@@ -22,10 +22,10 @@ import { fastHash, tokenize } from '../src/utils';
 import { loadAllLists } from './utils';
 
 describe('ReverseIndex', () => {
-  for (const config of [
+  [
     new Config({ enableCompression: true }),
     new Config({ enableCompression: false }),
-  ]) {
+  ].forEach((config) => {
     describe(`compression = ${config.enableCompression}`, () => {
       const { cosmeticFilters, networkFilters } = parseFilters(loadAllLists(), { debug: true });
 
@@ -43,8 +43,11 @@ describe('ReverseIndex', () => {
           });
 
           // Serialize index
-          const buffer = StaticDataView.allocate(10000000, config);
+          const buffer = StaticDataView.allocate(reverseIndex.getSerializedSize(), config);
           reverseIndex.serialize(buffer);
+
+          // Make sure that we predicted serialized size properly
+          expect(buffer.pos).toBe(buffer.buffer.byteLength);
 
           // Deserialize
           buffer.seekZero();
@@ -298,5 +301,5 @@ wildcard
         });
       }
     });
-  }
+  });
 });

--- a/packages/adblocker/test/serialization.test.ts
+++ b/packages/adblocker/test/serialization.test.ts
@@ -55,10 +55,9 @@ describe('Serialization', () => {
   });
 
   describe('Engine', () => {
-    const buffer = new Uint8Array(15000000);
     it('fails with wrong version', () => {
       const engine = Engine.parse('||domain');
-      const serialized = engine.serialize(buffer);
+      const serialized = engine.serialize();
       const version = serialized[0];
       serialized[0] = 1; // override version
       expect(() => {
@@ -70,7 +69,7 @@ describe('Serialization', () => {
 
     it('check integrity', () => {
       const engine = Engine.parse('||domain', { integrityCheck: true });
-      const serialized = engine.serialize(buffer);
+      const serialized = engine.serialize();
       for (let i = 0; i < serialized.length; i += 1) {
         const value = serialized[i];
         let randomValue = value;
@@ -92,7 +91,7 @@ describe('Serialization', () => {
 
     it('disable integrity check', () => {
       const engine = Engine.parse('||domain', { integrityCheck: true });
-      const serialized = engine.serialize(buffer);
+      const serialized = engine.serialize();
 
       const end = serialized.length - 1;
       const value = serialized[end];
@@ -115,13 +114,12 @@ describe('Serialization', () => {
         newNetworkFilters: networkFilters,
       });
 
-      const array = new Uint8Array(10000000);
-      const baseSerialized = engine.serialize(array);
+      const baseSerialized = engine.serialize();
 
       let deserialized = Engine.deserialize(baseSerialized);
       expect(deserialized).toEqual(engine);
 
-      let serialized = deserialized.serialize(array);
+      let serialized = deserialized.serialize();
       expect(typedArrayEqual(serialized, baseSerialized)).toBe(true);
 
       // Perform several deserializations in a row. Testing this is needed to
@@ -129,7 +127,7 @@ describe('Serialization', () => {
       // data.
       for (let i = 0; i < 3; i += 1) {
         deserialized = Engine.deserialize(serialized);
-        serialized = deserialized.serialize(array);
+        serialized = deserialized.serialize();
         expect(typedArrayEqual(serialized, baseSerialized)).toBe(true);
       }
     });

--- a/packages/adblocker/test/serialization.test.ts
+++ b/packages/adblocker/test/serialization.test.ts
@@ -22,6 +22,21 @@ describe('Serialization', () => {
     new Config({ debug: true }),
   );
 
+  describe('Config', () => {
+    it('serializes with exact size', () => {
+      const config = new Config();
+      const buffer = StaticDataView.allocate(config.getSerializedSize(), config);
+      config.serialize(buffer);
+
+      // Check size
+      expect(buffer.slice()).toHaveLength(config.getSerializedSize());
+
+      // Check deserialization
+      buffer.seekZero();
+      expect(Config.deserialize(buffer)).toEqual(config);
+    });
+  });
+
   describe('filters', () => {
     const buffer = StaticDataView.allocate(1000000, { enableCompression: false });
     const checkFilterSerialization = (Filter: any, filter: IFilter) => {

--- a/packages/adblocker/test/stress-test-engine-update.ts
+++ b/packages/adblocker/test/stress-test-engine-update.ts
@@ -72,6 +72,14 @@ function replacer(option: string): string {
  */
 const REGEX = /third-party|first-party|object-subrequest|stylesheet|subdocument|xmlhttprequest|document/g;
 function normalizeFilters(rawFilter: string): string {
+  if (rawFilter.startsWith('|http*://$')) {
+    rawFilter = rawFilter.slice(9);
+  }
+
+  if (rawFilter.includes('object,object')) {
+    rawFilter = rawFilter.replace('object,object', 'object');
+  }
+
   const indexOfOptions = rawFilter.lastIndexOf('$');
   if (indexOfOptions === -1) {
     return rawFilter;
@@ -366,6 +374,7 @@ async function run() {
         for (const difference of diff1) {
           console.log(difference);
         }
+        continue; // TODO - ignore other checks?
       }
 
       const diff2 = filtersDiff(
@@ -374,11 +383,13 @@ async function run() {
         'fromUpdated',
         filtersFromUpdatedEngine,
       );
+
       if (diff2.length !== 0) {
         console.log('Found discrepancy in filters');
         for (const difference of diff2) {
           console.log(difference);
         }
+        continue; // TODO - ignore other checks?
       }
 
       const updatedEngineSerialized = previousEngine.serialize();

--- a/packages/adblocker/test/tsconfig.json
+++ b/packages/adblocker/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig",
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "commonjs",
+    "composite": true
+  },
+  "files": [
+    "stress-test-engine-update.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1230,9 +1230,9 @@
     once "^1.4.0"
 
 "@octokit/request@^5.0.0":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.0.1.tgz#6705c9a883db0ac0f58cee717e806b6575d4a199"
-  integrity sha512-SHOk/APYpfrzV1RNf7Ux8SZi+vZXhMIB2dBr4TQR6ExMX8R4jcy/0gHw26HLe1dWV7Wxe9WzYyDSEC0XwnoCSQ==
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.0.2.tgz#59a920451f24811c016ddc507adcc41aafb2dca5"
+  integrity sha512-z1BQr43g4kOL4ZrIVBMHwi68Yg9VbkRUyuAgqCp1rU3vbYa69+2gIld/+gHclw15bJWQnhqqyEb7h5a5EqgZ0A==
   dependencies:
     "@octokit/endpoint" "^5.1.0"
     "@octokit/request-error" "^1.0.1"
@@ -1243,9 +1243,9 @@
     universal-user-agent "^3.0.0"
 
 "@octokit/rest@^16.28.4":
-  version "16.28.6"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.28.6.tgz#9e73104077c9c06cf3b1628603b4b0c55a117809"
-  integrity sha512-ERfzS6g6ZNPJkEUclxLenr+UEncbymCe//IBrWWdp59nslYDeJboq07Ue9brX05Uv0+SY3kwA33cdiVBVPAOMQ==
+  version "16.28.7"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.28.7.tgz#a2c2db5b318da84144beba82d19c1a9dbdb1a1fa"
+  integrity sha512-cznFSLEhh22XD3XeqJw51OLSfyL2fcFKUO+v2Ep9MTAFfFLS1cK1Zwd1yEgQJmJoDnj4/vv3+fGGZweG+xsbIA==
   dependencies:
     "@octokit/request" "^5.0.0"
     "@octokit/request-error" "^1.0.2"
@@ -1391,9 +1391,9 @@
   integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==
 
 "@types/node@^10.12.18":
-  version "10.14.13"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.13.tgz#ac786d623860adf39a3f51d629480aacd6a6eec7"
-  integrity sha512-yN/FNNW1UYsRR1wwAoyOwqvDuLDtVXnaJTZ898XIw/Q5cCaeVAlVwvsmXLX5PuiScBYwZsZU4JYSHB3TvfdwvQ==
+  version "10.14.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.15.tgz#e8f7729b631be1b02ae130ff0b61f3e018000640"
+  integrity sha512-CBR5avlLcu0YCILJiDIXeU2pTw7UK/NIxfC63m7d7CVamho1qDEzXKkOtEauQRPMy6MI8mLozth+JJkas7HY6g==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1467,9 +1467,9 @@ acorn-dynamic-import@4.0.0:
   integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
 
 acorn-globals@^4.1.0, acorn-globals@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
-  integrity sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.3.tgz#a86f75b69680b8780d30edd21eee4e0ea170c05e"
+  integrity sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==
   dependencies:
     acorn "^6.0.1"
     acorn-walk "^6.0.1"
@@ -1495,9 +1495,9 @@ acorn@^5.5.3:
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
 
 acorn@^6.0.1, acorn@^6.0.7, acorn@^6.1.1, acorn@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.1.tgz#3ed8422d6dec09e6121cc7a843ca86a330a86b51"
-  integrity sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
+  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
 
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
@@ -1530,10 +1530,17 @@ ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
+ansi-escapes@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+
+ansi-escapes@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.2.1.tgz#4dccdb846c3eee10f6d64dea66273eab90c37228"
+  integrity sha512-Cg3ymMAdN10wOk/VYfLV7KCQyv7EDirJ64500sU7n9UlmioEtDuU5Gd+hj73hXSU/ex7tHJSssmyftDdkMLO8Q==
+  dependencies:
+    type-fest "^0.5.2"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -1706,9 +1713,9 @@ astral-regex@^1.0.0:
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-limiter@^1.0.0, async-limiter@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
-  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1734,6 +1741,14 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
+
+axios@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
+  integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
+  dependencies:
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 axobject-query@^2.0.2:
   version "2.0.2"
@@ -2077,12 +2092,12 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
-    restore-cursor "^2.0.0"
+    restore-cursor "^3.1.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -2224,9 +2239,9 @@ config-chain@^1.1.11:
     proto-list "~1.2.1"
 
 confusing-browser-globals@^1.0.5:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.7.tgz#5ae852bd541a910e7ffb2dbb864a2d21a36ad29b"
-  integrity sha512-cgHI1azax5ATrZ8rJ+ODDML9Fvu67PimB6aNxBrc/QwSaDaM9eTfIEUHx3bBLJJ82ioSb+/5zfsMCCEJax3ByQ==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.8.tgz#93ffec1f82a6e2bf2bc36769cc3a92fa20e502f3"
+  integrity sha512-lI7asCibVJ6Qd3FGU7mu4sfG4try4LX3+GVS+Gv8UlrEf2AeW57piecapnog2UHZSbcX/P/1UDWVaTsblowlZg==
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -2255,17 +2270,17 @@ conventional-changelog-angular@^5.0.3:
     q "^1.5.1"
 
 conventional-changelog-core@^3.1.6:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz#de41e6b4a71011a18bcee58e744f6f8f0e7c29c0"
-  integrity sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-core/-/conventional-changelog-core-3.2.3.tgz#b31410856f431c847086a7dcb4d2ca184a7d88fb"
+  integrity sha512-LMMX1JlxPIq/Ez5aYAYS5CpuwbOk6QFp8O4HLAcZxe3vxoCtABkhfjetk8IYdRB9CDQGwJFLR3Dr55Za6XKgUQ==
   dependencies:
-    conventional-changelog-writer "^4.0.5"
-    conventional-commits-parser "^3.0.2"
+    conventional-changelog-writer "^4.0.6"
+    conventional-commits-parser "^3.0.3"
     dateformat "^3.0.0"
     get-pkg-repo "^1.0.0"
     git-raw-commits "2.0.0"
     git-remote-origin-url "^2.0.0"
-    git-semver-tags "^2.0.2"
+    git-semver-tags "^2.0.3"
     lodash "^4.2.1"
     normalize-package-data "^2.3.5"
     q "^1.5.1"
@@ -2274,19 +2289,19 @@ conventional-changelog-core@^3.1.6:
     through2 "^3.0.0"
 
 conventional-changelog-preset-loader@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz#65bb600547c56d5627d23135154bcd9a907668c4"
-  integrity sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.2.0.tgz#571e2b3d7b53d65587bea9eedf6e37faa5db4fcc"
+  integrity sha512-zXB+5vF7D5Y3Cb/rJfSyCCvFphCVmF8mFqOdncX3BmjZwAtGAPfYrBcT225udilCKvBbHgyzgxqz2GWDB5xShQ==
 
-conventional-changelog-writer@^4.0.5:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.6.tgz#24db578ac8e7c89a409ef9bba12cf3c095990148"
-  integrity sha512-ou/sbrplJMM6KQpR5rKFYNVQYesFjN7WpNGdudQSWNi6X+RgyFUcSv871YBYkrUYV9EX8ijMohYVzn9RUb+4ag==
+conventional-changelog-writer@^4.0.6:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-writer/-/conventional-changelog-writer-4.0.7.tgz#e4b7d9cbea902394ad671f67108a71fa90c7095f"
+  integrity sha512-p/wzs9eYaxhFbrmX/mCJNwJuvvHR+j4Fd0SQa2xyAhYed6KBiZ780LvoqUUvsayP4R1DtC27czalGUhKV2oabw==
   dependencies:
     compare-func "^1.3.1"
     conventional-commits-filter "^2.0.2"
     dateformat "^3.0.0"
-    handlebars "^4.1.0"
+    handlebars "^4.1.2"
     json-stringify-safe "^5.0.1"
     lodash "^4.2.1"
     meow "^4.0.0"
@@ -2315,7 +2330,7 @@ conventional-commits-parser@^2.1.0:
     through2 "^2.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-commits-parser@^3.0.2:
+conventional-commits-parser@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/conventional-commits-parser/-/conventional-commits-parser-3.0.3.tgz#c3f972fd4e056aa8b9b4f5f3d0e540da18bf396d"
   integrity sha512-KaA/2EeUkO4bKjinNfGUyqPTX/6w9JGshuQRik4r/wJz7rUw3+D3fDG6sZSEqJvKILzKXFQuFkpPLclcsAuZcg==
@@ -2329,16 +2344,16 @@ conventional-commits-parser@^3.0.2:
     trim-off-newlines "^1.0.0"
 
 conventional-recommended-bump@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-5.0.0.tgz#019d45a1f3d2cc14a26e9bad1992406ded5baa23"
-  integrity sha512-CsfdICpbUe0pmM4MTG90GPUqnFgB1SWIR2HAh+vS+JhhJdPWvc0brs8oadWoYGhFOQpQwe57JnvzWEWU0m2OSg==
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/conventional-recommended-bump/-/conventional-recommended-bump-5.0.1.tgz#5af63903947b6e089e77767601cb592cabb106ba"
+  integrity sha512-RVdt0elRcCxL90IrNP0fYCpq1uGt2MALko0eyeQ+zQuDVWtMGAy9ng6yYn3kax42lCj9+XBxQ8ZN6S9bdKxDhQ==
   dependencies:
     concat-stream "^2.0.0"
     conventional-changelog-preset-loader "^2.1.1"
     conventional-commits-filter "^2.0.2"
-    conventional-commits-parser "^3.0.2"
+    conventional-commits-parser "^3.0.3"
     git-raw-commits "2.0.0"
-    git-semver-tags "^2.0.2"
+    git-semver-tags "^2.0.3"
     meow "^4.0.0"
     q "^1.5.1"
 
@@ -2461,7 +2476,7 @@ debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
+debug@3.1.0, debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -2715,6 +2730,11 @@ emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2984,9 +3004,9 @@ estree-walker@^0.6.1:
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-  integrity sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -3150,10 +3170,10 @@ figgy-pudding@^3.4.1, figgy-pudding@^3.5.1:
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
 
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+figures@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.0.0.tgz#756275c964646163cc6f9197c7a0295dbfd04de9"
+  integrity sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==
   dependencies:
     escape-string-regexp "^1.0.5"
 
@@ -3225,6 +3245,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3417,13 +3444,13 @@ git-remote-origin-url@^2.0.0:
     gitconfiglocal "^1.0.0"
     pify "^2.3.0"
 
-git-semver-tags@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-2.0.2.tgz#f506ec07caade191ac0c8d5a21bdb8131b4934e3"
-  integrity sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==
+git-semver-tags@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/git-semver-tags/-/git-semver-tags-2.0.3.tgz#48988a718acf593800f99622a952a77c405bfa34"
+  integrity sha512-tj4FD4ww2RX2ae//jSrXZzrocla9db5h0V7ikPl1P/WwoZar9epdUhwR7XHXSgc+ZkNq72BEEerqQuicoEQfzA==
   dependencies:
     meow "^4.0.0"
-    semver "^5.5.0"
+    semver "^6.0.0"
 
 git-up@^4.0.0:
   version "4.0.1"
@@ -3547,16 +3574,16 @@ google-closure-compiler@20190618.0.0:
     google-closure-compiler-windows "^20190618.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.0.tgz#8d8fdc73977cb04104721cb53666c1ca64cd328b"
-  integrity sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.1.tgz#1c1f0c364882c868f5bff6512146328336a11b1d"
+  integrity sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw==
 
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.1.0, handlebars@^4.1.2:
+handlebars@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -3634,9 +3661,9 @@ has@^1.0.1, has@^1.0.3:
     function-bind "^1.1.1"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.6.0:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
-  integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.3.tgz#622638609162d788c6c7cc8c491442e7bbdff03e"
+  integrity sha512-gSxJXCMa4wZSq9YqCxcVWWtXw63FNFSx9XmDfet4IJg0vuiwxAdiLqbgxZty2/X5gHHd9F36v4VmEcAlZMgnGw==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
@@ -3802,21 +3829,21 @@ init-package-json@^1.10.3:
     validate-npm-package-name "^3.0.0"
 
 inquirer@^6.2.0, inquirer@^6.2.2:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
-  integrity sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.1.tgz#8bfb7a5ac02dac6ff641ac4c5ff17da112fcdb42"
+  integrity sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==
   dependencies:
-    ansi-escapes "^3.2.0"
+    ansi-escapes "^4.2.1"
     chalk "^2.4.2"
-    cli-cursor "^2.1.0"
+    cli-cursor "^3.1.0"
     cli-width "^2.0.0"
     external-editor "^3.0.3"
-    figures "^2.0.0"
-    lodash "^4.17.12"
-    mute-stream "0.0.7"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
     run-async "^2.2.0"
     rxjs "^6.4.0"
-    string-width "^2.1.0"
+    string-width "^4.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
@@ -3865,6 +3892,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-callable@^1.1.4:
   version "1.1.4"
@@ -3955,6 +3987,11 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-generator-fn@^2.0.0:
   version "2.1.0"
@@ -4688,7 +4725,7 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
 
-kleur@^3.0.2:
+kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
@@ -4866,7 +4903,7 @@ lodash@4.17.14:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -5048,9 +5085,9 @@ merge-stream@^1.0.1:
     readable-stream "^2.0.1"
 
 merge2@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.3.tgz#7ee99dbd69bb6481689253f018488a1b902b0ed5"
-  integrity sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA==
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.4.tgz#c9269589e6885a60cf80605d9522d4b67ca646e3"
+  integrity sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A==
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -5088,12 +5125,7 @@ mime@^2.0.3:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
-
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -5218,12 +5250,7 @@ multimatch@^3.0.0:
     arrify "^1.0.1"
     minimatch "^3.0.4"
 
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
-
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -5325,9 +5352,9 @@ node-modules-regexp@^1.0.0:
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-notifier@^5.2.1:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.0.tgz#7b455fdce9f7de0c63538297354f3db468426e6a"
-  integrity sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.1.tgz#7c0192cc63aedb25cd99619174daa27902b10903"
+  integrity sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==
   dependencies:
     growly "^1.3.0"
     is-wsl "^1.1.0"
@@ -5577,12 +5604,12 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
   dependencies:
-    mimic-fn "^1.0.0"
+    mimic-fn "^2.1.0"
 
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
@@ -6038,12 +6065,12 @@ promise-retry@^1.1.1:
     retry "^0.10.0"
 
 prompts@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
-  integrity sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"
+  integrity sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==
   dependencies:
-    kleur "^3.0.2"
-    sisteransi "^1.0.0"
+    kleur "^3.0.3"
+    sisteransi "^1.0.3"
 
 promzard@^0.3.0:
   version "0.3.0"
@@ -6084,9 +6111,9 @@ proxy-from-env@^1.0.0:
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
 psl@^1.1.24, psl@^1.1.28:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.2.0.tgz#df12b5b1b3a30f51c329eacbdef98f3a6e136dc6"
-  integrity sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.3.0.tgz#e1ebf6a3b5564fa8376f3da2275da76d875ca1bd"
+  integrity sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag==
 
 pump@^2.0.0:
   version "2.0.1"
@@ -6163,9 +6190,9 @@ rc@^1.2.1, rc@^1.2.7:
     strip-json-comments "~2.0.1"
 
 react-is@^16.8.1, react-is@^16.8.4:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 read-cmd-shim@^1.0.1:
   version "1.0.1"
@@ -6493,18 +6520,18 @@ resolve@1.1.7:
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
 resolve@1.x, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.11.1, resolve@^1.3.2, resolve@^1.5.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
-  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
+  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
-  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
   dependencies:
-    onetime "^2.0.0"
+    onetime "^5.1.0"
     signal-exit "^3.0.2"
 
 ret@~0.1.10:
@@ -6597,7 +6624,7 @@ rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
@@ -6660,9 +6687,9 @@ semver-compare@^1.0.0:
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
-  integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@6.1.1:
   version "6.1.1"
@@ -6723,10 +6750,10 @@ single-line-log@^1.1.2:
   dependencies:
     string-width "^1.0.1"
 
-sisteransi@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.2.tgz#ec57d64b6f25c4f26c0e2c7dd23f2d7f12f7e418"
-  integrity sha512-ZcYcZcT69nSLAR2oLN2JwNmLkJEKGooFMCdvOkFrToUt/WfcRWqhIg4P4KwY4dmLbuyXIx4o4YmPsvMRJYJd/w==
+sisteransi@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.3.tgz#98168d62b79e3a5e758e27ae63c4a053d748f4eb"
+  integrity sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==
 
 slash@^1.0.0:
   version "1.0.0"
@@ -6827,9 +6854,9 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-support@^0.5.6:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
-  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -6986,7 +7013,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -7003,12 +7030,21 @@ string-width@^3.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string_decoder@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.2.0.tgz#fe86e738b19544afe70469243b2a1ee9240eae8d"
-  integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
+string-width@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.1.0.tgz#ba846d1daa97c3c596155308063e075ed1c99aff"
+  integrity sha512-NrX+1dVVh+6Y9dnQ19pR0pP4FiEIlUvdTGn8pw6CKTNq5sgib2nIhmUNT5TAmhWmvKr3WcxBcP3E8nWezuipuQ==
   dependencies:
-    safe-buffer "~5.1.0"
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^5.2.0"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
@@ -7036,7 +7072,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.0.0, strip-ansi@^5.1.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -7113,9 +7149,9 @@ symbol-tree@^3.2.2:
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 table@^5.2.3:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.4.4.tgz#6e0f88fdae3692793d1077fd172a4667afe986a6"
-  integrity sha512-IIfEAUx5QlODLblLrGTTLJA7Tk0iLSGBvgY8essPRVNGHAzThujww1YqHLs6h3HfTg55h++RzLHH5Xw/rfv+mg==
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.5.tgz#c8f4ea2d8fee08c0027fac27b0ec0a4fe01dfa42"
+  integrity sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==
   dependencies:
     ajv "^6.10.2"
     lodash "^4.17.14"
@@ -7401,10 +7437,10 @@ tslint@^5.18.0:
     tslib "^1.8.0"
     tsutils "^2.29.0"
 
-tsmaz@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tsmaz/-/tsmaz-1.2.2.tgz#74683dd71d6440b1ac2c1dd999175ce4821967f1"
-  integrity sha512-eqet1z09AtigITA7RyTiehtqNSWdXYp58XSkf7fpcLatYZDE0NmC/EL4LnbI9VUpYZPeMuIGLhW6jSNSZo62jg==
+tsmaz@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tsmaz/-/tsmaz-1.3.0.tgz#389196d6ac36b641079892e729b9160f4a1dd382"
+  integrity sha512-vcU8dokp/QecvbTldQIE9Y4MD+ObU8VOpkwKCvhwhLv+yVdLMyjq7vTuc/haLLclRFRtMRj2z+qR7IjN+fnpiQ==
 
 tsutils@^2.29.0:
   version "2.29.0"
@@ -7436,6 +7472,11 @@ type-fest@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
+
+type-fest@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
+  integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
 type-fest@^0.6.0:
   version "0.6.0"
@@ -7790,9 +7831,9 @@ ws@^6.1.0:
     async-limiter "~1.0.0"
 
 ws@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.1.1.tgz#f9942dc868b6dffb72c14fd8f2ba05f77a4d5983"
-  integrity sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.1.2.tgz#c672d1629de8bb27a9699eb599be47aeeedd8f73"
+  integrity sha512-gftXq3XI81cJCgkUiAVixA0raD9IVmXqsylCrjRygw4+UOOGzPoxnQ6r/CnVL9i+mDncJo94tSkyrtuuQVBmrg==
   dependencies:
     async-limiter "^1.0.0"
 
@@ -7869,6 +7910,6 @@ yauzl@2.4.1:
     fd-slicer "~1.0.1"
 
 yn@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.0.tgz#fcbe2db63610361afcc5eb9e0ac91e976d046114"
-  integrity sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
Implement a mechanism which allows to predict the number of bytes needed to serialize any of the data-structures used by the adblocker, ahead of time (before serialization). This allows to lift the limitation of size completely (beforehand, we had to allocate a safe amount of memory to be sure there would be enough space). As a benefit, only the required amount of memory is used during initialization and updates, and there is no longer an arbitrary and hard-coded upper limit.

A few consequences:

* most classes now expose a `getSerializedSize(...)` method which returns the number of bytes needed to serialize this particular instance.
* the internal structure of `ReverseIndex` has been optimized so that the memory layout is now closer to access patterns (there is a forward progression in the way values are read from memory at runtime)
* documentation has been improved to better explain the way internal data-structures work and why they are implemented in this specific way.
* the bug which prevented us from using `subarray(...)` to deserialize bytes is now resolved and the un-necessary copies (using `slice(...)`) are gone!

Fixes #257 
Fixes #91 