### PR TITLE
Release v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 *not released*
 
+## 0.12.1
+
+*2019-08-13*
+
+  *  Update assets + re-generate compression codebooks [#256](https://github.com/cliqz-oss/adblocker/pull/256)
+  * implement simple event emitter for `FiltersEngine` and sub-classes [#251](https://github.com/cliqz-oss/adblocker/pull/251)
+  * electron: fix bundles [#249](https://github.com/cliqz-oss/adblocker/pull/249)
+  * electron: promote mutationObserver option to main config + fix constructor and parse methods [#248](https://github.com/cliqz-oss/adblocker/pull/248)
   * fix source maps support for all packages [#219](https://github.com/cliqz-oss/adblocker/pull/219)
 
 ## 0.12.0

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.12.0"
+  "version": "0.12.1"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Content blockers benchmark",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.0",
+    "@cliqz/adblocker": "^0.12.1",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   }

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -42,6 +42,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.0"
+    "@cliqz/adblocker": "^0.12.1"
   }
 }

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-electron": "^0.12.0",
+    "@cliqz/adblocker-electron": "^0.12.1",
     "@types/node-fetch": "^2.5.0",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker Electron wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,8 +35,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.0"
+    "@cliqz/adblocker": "^0.12.1",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1"
   },
   "devDependencies": {
     "jest": "^24.8.0",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -22,7 +22,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^0.12.0",
+    "@cliqz/adblocker-puppeteer": "^0.12.1",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,7 +35,7 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.0",
+    "@cliqz/adblocker": "^0.12.1",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -45,6 +45,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.0"
+    "@cliqz/adblocker": "^0.12.1"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^0.12.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.0"
+    "@cliqz/adblocker-webextension": "^0.12.1",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -45,8 +45,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.0",
+    "@cliqz/adblocker": "^0.12.1",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1",
     "tldts-experimental": "^5.3.0"
   }
 }

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cliqz adblocker library",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",


### PR DESCRIPTION
  * Update assets + re-generate compression codebooks [#256](https://github.com/cliqz-oss/adblocker/pull/256)
  * implement simple event emitter for `FiltersEngine` and sub-classes [#251](https://github.com/cliqz-oss/adblocker/pull/251)
  * electron: fix bundles [#249](https://github.com/cliqz-oss/adblocker/pull/249)
  * electron: promote mutationObserver option to main config + fix constructor and parse methods [#248](https://github.com/cliqz-oss/adblocker/pull/248)
  * fix source maps support for all packages [#219](https://github.com/cliqz-oss/adblocker/pull/219)