### PR TITLE
provide helpers to download and build engines from lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,50 @@
     > have this issue again, all these content-scripts helpers are moved
     > into their own package.
 
+  * provide helpers to download and build engines from lists [#280](https://github.com/cliqz-oss/adblocker/pull/280)
+
+    > This change allows to start blocking ads with very little logic in
+    > _Webextension_, _Electron_ and _Puppeteer_ platforms! To achieve this,
+    > blockers abstraction now provide static methods to fetch pre-built
+    > engines from Cliqz's CDN or build them from scratch using lists of URLs
+    > to subscriptions. Here is how it looks like:
+    >
+    > *Webextension*:
+    > ```js
+    > import { WebExtensionBlocker } from '@cliqz/adblocker-webextension';
+    >
+    > WebExtensionBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
+    >   blocker.enableBlockingInBrowser();
+    > });
+    > ```
+    >
+    > *Electron*:
+    > ```js
+    > import { session } from 'electron';
+    > import fetch from 'cross-fetch'; // or 'node-fetch'
+    >
+    > import { ElectronBlocker } from '@cliqz/adblocker-electron';
+    >
+    > ElectronBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
+    >   blocker.enableBlockingInSession(session.defaultSession);
+    > });
+    > ```
+    >
+    > *Puppeteer*:
+    > ```js
+    > import puppeteer from 'puppeteer';
+    > import fetch from 'cross-fetch'; // or 'node-fetch'
+    >
+    > import { PuppeteerBlocker } from '@cliqz/adblocker-puppeteer';
+    >
+    > const browser = await puppeteer.launch();
+    > const page = await browser.newPage();
+    >
+    > PuppeteerBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
+    >   blocker.enableBlockingInPage(page);
+    > });
+    > ```
+
 ## 0.12.1
 
 *2019-08-13*

--- a/packages/adblocker-puppeteer-example/index.ts
+++ b/packages/adblocker-puppeteer-example/index.ts
@@ -1,58 +1,9 @@
-import { fetchLists, fetchResources, PuppeteerBlocker, Request } from '@cliqz/adblocker-puppeteer';
+import { fullLists, PuppeteerBlocker, Request } from '@cliqz/adblocker-puppeteer';
 import fetch from 'node-fetch';
 import puppeteer from 'puppeteer';
 
-// Polyfill fetch API for Node.js environment
-// @ts-ignore
-global.fetch = fetch;
-
-/**
- * Initialize the adblocker using lists of filters and resources. It returns a
- * Promise resolving on the `Engine` that we will use to decide what requests
- * should be blocked or altered.
- */
-async function loadAdblocker(): Promise<PuppeteerBlocker> {
-  console.log('Fetching resources...');
-  return Promise.all([fetchLists(), fetchResources()]).then(([responses, resources]) => {
-    console.log('Initialize adblocker...');
-    const deduplicatedLines = new Set();
-    for (let i = 0; i < responses.length; i += 1) {
-      const lines = responses[i].split(/\n/g);
-      for (let j = 0; j < lines.length; j += 1) {
-        deduplicatedLines.add(lines[j]);
-      }
-    }
-    const deduplicatedFilters = Array.from(deduplicatedLines).join('\n');
-
-    let t0 = Date.now();
-    const engine = PuppeteerBlocker.parse(deduplicatedFilters, {
-      enableCompression: true,
-    });
-    let total = Date.now() - t0;
-    console.log('parsing filters', total);
-
-    t0 = Date.now();
-    engine.updateResources(resources, '' + resources.length);
-    total = Date.now() - t0;
-    console.log('parsing resources', total);
-
-    t0 = Date.now();
-    const serialized = engine.serialize();
-    total = Date.now() - t0;
-    console.log('serialization', total);
-    console.log('size', serialized.byteLength);
-
-    t0 = Date.now();
-    const deserialized = PuppeteerBlocker.deserialize(serialized);
-    total = Date.now() - t0;
-    console.log('deserialization', total);
-
-    return deserialized as PuppeteerBlocker;
-  });
-}
-
 (async () => {
-  const engine = await loadAdblocker();
+  const engine = await PuppeteerBlocker.fromLists(fetch, fullLists);
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: false,

--- a/packages/adblocker-webextension-example/background.ts
+++ b/packages/adblocker-webextension-example/background.ts
@@ -6,52 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { BlockingResponse, fetchLists, fetchResources, Request, WebExtensionBlocker } from '@cliqz/adblocker-webextension';
-
-/**
- * Initialize the adblocker using lists of filters and resources. It returns a
- * Promise resolving on the `Engine` that we will use to decide what requests
- * should be blocked or altered.
- */
-function loadAdblocker() {
-  console.log('Fetching resources...');
-  return Promise.all([fetchLists(), fetchResources()]).then(([responses, resources]) => {
-    console.log('Initialize adblocker...');
-    const deduplicatedLines = new Set();
-    for (let i = 0; i < responses.length; i += 1) {
-      const lines = responses[i].split(/\n/g);
-      for (let j = 0; j < lines.length; j += 1) {
-        deduplicatedLines.add(lines[j]);
-      }
-    }
-    const deduplicatedFilters = Array.from(deduplicatedLines).join('\n');
-
-    let t0 = Date.now();
-    const engine = WebExtensionBlocker.parse(deduplicatedFilters, {
-      enableCompression: true,
-    });
-    let total = Date.now() - t0;
-    console.log('parsing filters', total);
-
-    t0 = Date.now();
-    engine.updateResources(resources, '' + resources.length);
-    total = Date.now() - t0;
-    console.log('parsing resources', total);
-
-    t0 = Date.now();
-    const serialized = engine.serialize();
-    total = Date.now() - t0;
-    console.log('serialization', total);
-    console.log('size', serialized.byteLength);
-
-    t0 = Date.now();
-    const deserialized = WebExtensionBlocker.deserialize(serialized);
-    total = Date.now() - t0;
-    console.log('deserialization', total);
-
-    return deserialized as WebExtensionBlocker;
-  });
-}
+import { BlockingResponse, fullLists, Request, WebExtensionBlocker } from '@cliqz/adblocker-webextension';
 
 /**
  * Keep track of number of network requests altered for each tab
@@ -82,10 +37,22 @@ chrome.tabs.onActivated.addListener(({ tabId }: chrome.tabs.TabActiveInfo) =>
   updateBlockedCounter(tabId),
 );
 
-loadAdblocker().then((engine) => {
+WebExtensionBlocker.fromLists(fetch, fullLists).then((engine: WebExtensionBlocker) => {
   engine.enableBlockingInBrowser();
   engine.on('request-blocked', incrementBlockedCounter);
   engine.on('request-redirected', incrementBlockedCounter);
+
+  engine.on('csp-injected', (request: Request) => {
+    console.log('csp', request.url);
+  });
+
+  engine.on('script-injected', (script: string, url: string) => {
+    console.log('script', script.length, url);
+  });
+
+  engine.on('style-injected', (style: string, url: string) => {
+    console.log('style', style.length, url);
+  });
 
   console.log('Ready to roll!');
 });

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -29,6 +29,6 @@ export {
   getLinesWithFilters,
 } from './src/lists';
 export { compactTokens, hasEmptyIntersection, mergeCompactSets } from './src/compact-set';
-export { fetchLists, fetchResources } from './src/fetch';
+export * from './src/fetch';
 export { tokenize } from './src/utils';
 export { default as Config } from './src/config';


### PR DESCRIPTION
This change allows to start blocking ads with very little logic in _Webextension_, _Electron_ and _Puppeteer_ platforms! To achieve this, blockers abstraction now provide static methods to fetch pre-built engines from Cliqz's CDN or build them from scratch using lists of URLs to subscriptions. Here is how it looks like:

*Webextension*:
```js
import { WebExtensionBlocker } from '@cliqz/adblocker-webextension';

WebExtensionBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
  blocker.enableBlockingInBrowser();
});
```

*Electron*:
```js
import { session } from 'electron';
import fetch from 'cross-fetch'; // or 'node-fetch'

import { ElectronBlocker } from '@cliqz/adblocker-electron';

ElectronBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
  blocker.enableBlockingInSession(session.defaultSession);
});
```

*Puppeteer*:
```js
import puppeteer from 'puppeteer';
import fetch from 'cross-fetch'; // or 'node-fetch'

import { PuppeteerBlocker } from '@cliqz/adblocker-puppeteer';

const browser = await puppeteer.launch();
const page = await browser.newPage();

PuppeteerBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
  blocker.enableBlockingInPage(page);
});
```

Fixes #216 