### PR TITLE
Release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released*
 
+## 0.13.0
+
+*2019-08-16*
+
   * allow correct size allocation for data views [#257](https://github.com/cliqz-oss/adblocker/pull/257)
 
     > Implement a mechanism which allows to predict the number of

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.12.1"
+  "version": "0.13.0"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Content blockers benchmark",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1",
+    "@cliqz/adblocker": "^0.13.0",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   }

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -42,6 +42,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^0.12.1"
+    "@cliqz/adblocker-content": "^0.13.0"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-electron": "^0.12.1",
+    "@cliqz/adblocker-electron": "^0.13.0",
     "@types/node-fetch": "^2.5.0",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker Electron wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,8 +35,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1",
-    "@cliqz/adblocker-content": "^0.12.1"
+    "@cliqz/adblocker": "^0.13.0",
+    "@cliqz/adblocker-content": "^0.13.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -22,7 +22,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^0.12.1",
+    "@cliqz/adblocker-puppeteer": "^0.13.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,8 +35,8 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1",
-    "@cliqz/adblocker-content": "^0.12.1",
+    "@cliqz/adblocker": "^0.13.0",
+    "@cliqz/adblocker-content": "^0.13.0",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -45,6 +45,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^0.12.1"
+    "@cliqz/adblocker-content": "^0.13.0"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^0.12.1",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.12.1"
+    "@cliqz/adblocker-webextension": "^0.13.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.13.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -45,8 +45,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.12.1",
-    "@cliqz/adblocker-content": "^0.12.1",
+    "@cliqz/adblocker": "^0.13.0",
+    "@cliqz/adblocker-content": "^0.13.0",
     "tldts-experimental": "^5.3.0"
   }
 }

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Cliqz adblocker library",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",


### PR DESCRIPTION
This release is the last one before long-awaited stable release: `v1.0.0`! (unless some serious issue is found). On `v0.13.0` some of the latest long-standing issues were fixed and the project is now more polished and easy to use.

* allow correct size allocation for data views [#257](https://github.com/cliqz-oss/adblocker/pull/257)

  > Implement a mechanism which allows to predict the number of
  > bytes needed to serialize any of the data-structures used by the
  > adblocker, ahead of time (before serialization). This allows to lift
  > the limitation of size completely (beforehand, we had to allocate
  > a safe amount of memory to be sure there would be enough space).
  > As a benefit, only the required amount of memory is used during
  > initialization and updates, and there is no longer an arbitrary and
  > hard-coded upper limit.

* create new @cliqz/adblocker-content package with common utils [#264](https://github.com/cliqz-oss/adblocker/pull/264)

  > We currently rely on rollup to create a small bundle for content
  > related code imported from @cliqz/adblocker. Multiple times in
  > the past the bundler was not aggressive enough and code from
  > background was pulled in content bundles. To make sure we do not
  > have this issue again, all these content-scripts helpers are moved
  > into their own package.

* provide helpers to download and build engines from lists [#280](https://github.com/cliqz-oss/adblocker/pull/280)

  > This change allows to start blocking ads with very little logic in
  > _Webextension_, _Electron_ and _Puppeteer_ platforms! To achieve this,
  > blockers abstraction now provide static methods to fetch pre-built
  > engines from Cliqz's CDN or build them from scratch using lists of URLs
  > to subscriptions. Here is how it looks like:
  >
  > *Webextension*:
  > ```js
  > import { WebExtensionBlocker } from '@cliqz/adblocker-webextension';
  >
  > WebExtensionBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
  >   blocker.enableBlockingInBrowser();
  > });
  > ```
  >
  > *Electron*:
  > ```js
  > import { session } from 'electron';
  > import fetch from 'cross-fetch'; // or 'node-fetch'
  >
  > import { ElectronBlocker } from '@cliqz/adblocker-electron';
  >
  > ElectronBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
  >   blocker.enableBlockingInSession(session.defaultSession);
  > });
  > ```
  >
  > *Puppeteer*:
  > ```js
  > import puppeteer from 'puppeteer';
  > import fetch from 'cross-fetch'; // or 'node-fetch'
  >
  > import { PuppeteerBlocker } from '@cliqz/adblocker-puppeteer';
  >
  > const browser = await puppeteer.launch();
  > const page = await browser.newPage();
  >
  > PuppeteerBlocker.fromPrebuiltAdsAndTracking(fetch).then((blocker) => {
  >   blocker.enableBlockingInPage(page);
  > });
  > ```