### PR TITLE
Release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released*
 
+## 0.14.0
+
+*2019-08-20*
+
   * update compression codebooks [#289](https://github.com/cliqz-oss/adblocker/pull/289)
   * clean-up and update local assets + add fanboy-cookiemonster.txt [#289](https://github.com/cliqz-oss/adblocker/pull/289)
   * only register listeners when network/cosmetics filtering is enabled [#288](https://github.com/cliqz-oss/adblocker/pull/288)

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.13.2"
+  "version": "0.14.0"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Content blockers benchmark",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.13.2",
+    "@cliqz/adblocker": "^0.14.0",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   }

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -42,6 +42,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^0.13.2"
+    "@cliqz/adblocker-content": "^0.14.0"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -23,7 +23,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-electron": "^0.13.2",
+    "@cliqz/adblocker-electron": "^0.14.0",
     "@types/node-fetch": "^2.5.0",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker Electron wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,8 +35,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.13.2",
-    "@cliqz/adblocker-content": "^0.13.2"
+    "@cliqz/adblocker": "^0.14.0",
+    "@cliqz/adblocker-content": "^0.14.0"
   },
   "devDependencies": {
     "jest": "^24.8.0",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -22,7 +22,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^0.13.2",
+    "@cliqz/adblocker-puppeteer": "^0.14.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -35,8 +35,8 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.13.2",
-    "@cliqz/adblocker-content": "^0.13.2",
+    "@cliqz/adblocker": "^0.14.0",
+    "@cliqz/adblocker-content": "^0.14.0",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -45,6 +45,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^0.13.2"
+    "@cliqz/adblocker-content": "^0.14.0"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -27,8 +27,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^0.13.2",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.13.2"
+    "@cliqz/adblocker-webextension": "^0.14.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^0.14.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",
@@ -45,8 +45,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.13.2",
-    "@cliqz/adblocker-content": "^0.13.2",
+    "@cliqz/adblocker": "^0.14.0",
+    "@cliqz/adblocker-content": "^0.14.0",
     "tldts-experimental": "^5.3.0"
   }
 }

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.13.2",
+  "version": "0.14.0",
   "description": "Cliqz adblocker library",
   "author": "Cliqz",
   "homepage": "https://github.com/cliqz-oss/adblocker#readme",


### PR DESCRIPTION
  * update compression codebooks [#289](https://github.com/cliqz-oss/adblocker/pull/289)
  * clean-up and update local assets + add fanboy-cookiemonster.txt [#289](https://github.com/cliqz-oss/adblocker/pull/289)
  * only register listeners when network/cosmetics filtering is enabled [#288](https://github.com/cliqz-oss/adblocker/pull/288)
  * Improve cosmetics selector tokenization by supporting new cases [#287](https://github.com/cliqz-oss/adblocker/pull/287)
    * correctly tokenize #selector:not(...) and .selector:not(...)
    * correctly tokenize .selector1.selector2
