### PR TITLE
small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 *not released*
 
+  * small improvements [#300](https://github.com/cliqz-oss/adblocker/pull/300)
+    * minify script injection wrapper to save a few bytes
+    * rename 'engine' into 'blocker' in examples for consistency
+    * use up-to-date resources.txt from CDN
+    * drop 'collapse' type (not supported upstream anymore)
+    * expose some extra symbols: `detectFilterType` and `Resources`
   * chore: clean-ups [#294](https://github.com/cliqz-oss/adblocker/pull/294)
     * Remove use of `eslint` completely (all source code is TypeScript so `tslint` is enough)
     * Remove `Dockerfile`, `run_tests.sh`

--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -84,20 +84,22 @@ export function extractFeaturesFromDOM(
  * traces in the DOM after injections.
  */
 export function autoRemoveScript(script: string): string {
-  return `
-try {
-  ${script}
-} catch (ex) { }
-
-(function() {
-  var currentScript = document.currentScript;
-  var parent = currentScript && currentScript.parentNode;
-
-  if (parent) {
-    parent.removeChild(currentScript);
-  }
-})();
-  `;
+  // Minified using 'terser'
+  return `try{${script}}catch(c){}!function(){var c=document.currentScript,e=c&&c.parentNode;e&&e.removeChild(c)}();`
+  // Original:
+  //
+  //    try {
+  //      ${script}
+  //    } catch (ex) { }
+  //
+  //    (function() {
+  //      var currentScript = document.currentScript;
+  //      var parent = currentScript && currentScript.parentNode;
+  //
+  //      if (parent) {
+  //        parent.removeChild(currentScript);
+  //      }
+  //    })();
 }
 
 export function injectCSSRule(rule: string, doc: Document): void {

--- a/packages/adblocker-puppeteer-example/index.ts
+++ b/packages/adblocker-puppeteer-example/index.ts
@@ -3,36 +3,36 @@ import fetch from 'node-fetch';
 import puppeteer from 'puppeteer';
 
 (async () => {
-  const engine = await PuppeteerBlocker.fromLists(fetch, fullLists);
+  const blocker = await PuppeteerBlocker.fromLists(fetch, fullLists);
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: false,
   });
 
   const page = await browser.newPage();
-  await engine.enableBlockingInPage(page);
+  await blocker.enableBlockingInPage(page);
 
-  engine.on('request-blocked', (request: Request) => {
+  blocker.on('request-blocked', (request: Request) => {
     console.log('blocked', request.url);
   });
 
-  engine.on('request-redirected', (request: Request) => {
+  blocker.on('request-redirected', (request: Request) => {
     console.log('redirected', request.url);
   });
 
-  engine.on('request-whitelisted', (request: Request) => {
+  blocker.on('request-whitelisted', (request: Request) => {
     console.log('whitelisted', request.url);
   });
 
-  engine.on('csp-injected', (request: Request) => {
+  blocker.on('csp-injected', (request: Request) => {
     console.log('csp', request.url);
   });
 
-  engine.on('script-injected', (script: string, url: string) => {
+  blocker.on('script-injected', (script: string, url: string) => {
     console.log('script', script.length, url);
   });
 
-  engine.on('style-injected', (style: string, url: string) => {
+  blocker.on('style-injected', (style: string, url: string) => {
     console.log('style', style.length, url);
   });
 

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -19,14 +19,15 @@ export {
 export { default as CosmeticFilter } from './src/filters/cosmetic';
 export { default as NetworkFilter } from './src/filters/network';
 export {
+  IListDiff,
+  IRawDiff,
+  detectFilterType,
   f,
+  generateDiff,
+  getLinesWithFilters,
+  mergeDiffs,
   parseFilter,
   parseFilters,
-  IRawDiff,
-  IListDiff,
-  generateDiff,
-  mergeDiffs,
-  getLinesWithFilters,
 } from './src/lists';
 export { compactTokens, hasEmptyIntersection, mergeCompactSets } from './src/compact-set';
 export * from './src/fetch';

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -33,3 +33,4 @@ export { compactTokens, hasEmptyIntersection, mergeCompactSets } from './src/com
 export * from './src/fetch';
 export { tokenize } from './src/utils';
 export { default as Config } from './src/config';
+export { default as Resources } from './src/resources';

--- a/packages/adblocker/src/fetch.ts
+++ b/packages/adblocker/src/fetch.ts
@@ -61,13 +61,22 @@ export function fetchLists(fetch: Fetch, urls: string[]): Promise<string[]> {
   return Promise.all(urls.map((url) => fetchResource(fetch, url)));
 }
 
+function getResourcesUrl(fetch: Fetch): Promise<string> {
+  return fetch('https://cdn.cliqz.com/adblocker/resources/ublock-resources/metadata.json')
+    .then((response) => response.json())
+    .then(
+      ({ latestRevision }) =>
+        `https://cdn.cliqz.com/adblocker/resources/ublock-resources/${latestRevision}/list.txt`,
+    );
+}
+
 /**
  * Fetch latest version of uBlock Origin's resources, used to inject scripts in
  * the page or redirect request to data URLs.
  */
-export function fetchResources(
-  fetch: Fetch,
-  resourcesUrl: string = 'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resources.txt',
-): Promise<string> {
-  return fetchResource(fetch, resourcesUrl);
+export function fetchResources(fetch: Fetch, resourcesUrl?: string): Promise<string> {
+  return (resourcesUrl === undefined
+    ? getResourcesUrl(fetch)
+    : Promise.resolve(resourcesUrl)
+  ).then((url) => fetchResource(fetch, url));
 }

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -354,8 +354,6 @@ export default class NetworkFilter implements IFilter {
           case 'fuzzy':
             mask = setBit(mask, NETWORK_FILTER_MASK.fuzzyMatch);
             break;
-          case 'collapse':
-            break;
           case 'redirect':
             // Negation of redirection doesn't make sense
             if (negation) {

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -12,9 +12,9 @@ import NetworkFilter from './filters/network';
 import { fastStartsWith, fastStartsWithFrom } from './utils';
 
 const enum FilterType {
-  NOT_SUPPORTED,
-  NETWORK,
-  COSMETIC,
+  NOT_SUPPORTED = 0,
+  NETWORK = 1,
+  COSMETIC = 2,
 }
 
 /**
@@ -23,7 +23,7 @@ const enum FilterType {
  * performed before calling a more specific parser to create an instance of
  * `NetworkFilter` or `CosmeticFilter`.
  */
-function detectFilterType(line: string): FilterType {
+export function detectFilterType(line: string): FilterType {
   // Ignore empty line
   if (line.length === 0 || line.length === 1) {
     return FilterType.NOT_SUPPORTED;

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -13,6 +13,9 @@ interface IResource {
   data: string;
 }
 
+// TODO - support # alias
+// TODO - support empty resource body
+
 /**
  * Abstraction on top of resources.txt used for redirections as well as script
  * injections. It contains logic to parse, serialize and get resources by name


### PR DESCRIPTION
* minify script injection wrapper to save a few bytes
* rename 'engine' into 'blocker' in examples for consistency
* use up-to-date resources.txt from CDN
* drop 'collapse' type (not supported upstream anymore)
* expose some extra symbols: `detectFilterType` and `Resources`