### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released*
 
+## 1.0.0
+
+*2019-08-27*
+
   * small improvements [#300](https://github.com/cliqz-oss/adblocker/pull/300)
     * minify script injection wrapper to save a few bytes
     * rename 'engine' into 'blocker' in examples for consistency

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.14.0"
+  "version": "1.0.0"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Content blockers benchmark",
   "author": {
     "name": "Cliqz"
@@ -25,7 +25,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.14.0",
+    "@cliqz/adblocker": "^1.0.0",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   },

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": {
     "name": "Cliqz"
@@ -78,6 +78,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^0.14.0"
+    "@cliqz/adblocker-content": "^1.0.0"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -59,7 +59,7 @@
     }
   ],
   "dependencies": {
-    "@cliqz/adblocker-electron": "^0.14.0",
+    "@cliqz/adblocker-electron": "^1.0.0",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker Electron wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.14.0",
-    "@cliqz/adblocker-content": "^0.14.0"
+    "@cliqz/adblocker": "^1.0.0",
+    "@cliqz/adblocker-content": "^1.0.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -24,7 +24,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^0.14.0",
+    "@cliqz/adblocker-puppeteer": "^1.0.0",
     "node-fetch": "^2.6.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.14.0",
-    "@cliqz/adblocker-content": "^0.14.0",
+    "@cliqz/adblocker": "^1.0.0",
+    "@cliqz/adblocker-content": "^1.0.0",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": {
     "name": "Cliqz"
@@ -84,6 +84,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^0.14.0"
+    "@cliqz/adblocker-content": "^1.0.0"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": {
     "name": "Cliqz"
@@ -29,8 +29,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^0.14.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^0.14.0"
+    "@cliqz/adblocker-webextension": "^1.0.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.0.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": {
     "name": "Cliqz"
@@ -50,8 +50,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^0.14.0",
-    "@cliqz/adblocker-content": "^0.14.0",
+    "@cliqz/adblocker": "^1.0.0",
+    "@cliqz/adblocker-content": "^1.0.0",
     "tldts-experimental": "^5.3.0"
   },
   "contributors": [

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "0.14.0",
+  "version": "1.0.0",
   "description": "Cliqz adblocker library",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -25,7 +25,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 34;
+export const ENGINE_VERSION = 35;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
This marks the first "stable release" of `@cliqz/adblocker`. The project has been stable for a long while and running in production for millions of users. It was about time to graduate it to `v1`! This does not mark the end of the development and innovation but more of a "checkbox ticked"; people looking at the project can now safely feel like they can use it in production and `@cliqz/adblocker` will not let them down! In the future, we will continue supporting bleeding edge features, new filters and keep the performance great.

Changelog since `v0.14.0`:

  * small improvements [#300](https://github.com/cliqz-oss/adblocker/pull/300)
    * minify script injection wrapper to save a few bytes
    * rename 'engine' into 'blocker' in examples for consistency
    * use up-to-date resources.txt from CDN
    * drop 'collapse' type (not supported upstream anymore)
    * expose some extra symbols: `detectFilterType` and `Resources`
  * chore: clean-ups [#294](https://github.com/cliqz-oss/adblocker/pull/294)
    * Remove use of `eslint` completely (all source code is TypeScript so `tslint` is enough)
    * Remove `Dockerfile`, `run_tests.sh`
    * Move `bench` to TypeScript
    * Remove un-used `bench/dataset/` folder
    * Make sure that all sub-packages can be installed and built independently (fix missing deps)
  * enable @cliqz/metalint for repository linting [#255](https://github.com/cliqz-oss/adblocker/pull/255)