### PR TITLE
fix: prevent preload script from overwriting existing ones

### DIFF
--- a/packages/adblocker-electron/adblocker.ts
+++ b/packages/adblocker-electron/adblocker.ts
@@ -53,7 +53,7 @@ export class ElectronBlocker extends FiltersEngine {
 
     if (this.config.loadCosmeticFilters === true) {
       ipcMain.on('get-cosmetic-filters', this.onGetCosmeticFilters);
-      ses.setPreloads([join(__dirname, './preload.js')]);
+      ses.setPreloads(ses.getPreloads().concat([join(__dirname, './preload.js')]));
       ipcMain.on('is-mutation-observer-enabled', (event: Electron.IpcMainEvent) => {
         event.returnValue = this.config.enableMutationObserver;
       });


### PR DESCRIPTION
Hi, I noticed in my project that `adblocker-electron` overwrites existing preloads, so I pushed a little fix.