### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 *not released*
 
+## 1.0.1
+
+*2019-08-28*
+
+  * fix (electron): prevent preload script from overwriting existing ones [#302](https://github.com/cliqz-oss/adblocker/pull/302)
+
 ## 1.0.0
 
 *2019-08-27*

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Content blockers benchmark",
   "author": {
     "name": "Cliqz"
@@ -25,7 +25,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.0.0",
+    "@cliqz/adblocker": "^1.0.1",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   },

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": {
     "name": "Cliqz"
@@ -78,6 +78,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.0.0"
+    "@cliqz/adblocker-content": "^1.0.1"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -59,7 +59,7 @@
     }
   ],
   "dependencies": {
-    "@cliqz/adblocker-electron": "^1.0.0",
+    "@cliqz/adblocker-electron": "^1.0.1",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker Electron wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.0.0",
-    "@cliqz/adblocker-content": "^1.0.0"
+    "@cliqz/adblocker": "^1.0.1",
+    "@cliqz/adblocker-content": "^1.0.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -24,7 +24,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^1.0.0",
+    "@cliqz/adblocker-puppeteer": "^1.0.1",
     "node-fetch": "^2.6.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.0.0",
-    "@cliqz/adblocker-content": "^1.0.0",
+    "@cliqz/adblocker": "^1.0.1",
+    "@cliqz/adblocker-content": "^1.0.1",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": {
     "name": "Cliqz"
@@ -84,6 +84,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.0.0"
+    "@cliqz/adblocker-content": "^1.0.1"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": {
     "name": "Cliqz"
@@ -29,8 +29,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^1.0.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^1.0.0"
+    "@cliqz/adblocker-webextension": "^1.0.1",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.0.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.88",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": {
     "name": "Cliqz"
@@ -50,8 +50,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.0.0",
-    "@cliqz/adblocker-content": "^1.0.0",
+    "@cliqz/adblocker": "^1.0.1",
+    "@cliqz/adblocker-content": "^1.0.1",
     "tldts-experimental": "^5.3.0"
   },
   "contributors": [

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cliqz adblocker library",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -25,7 +25,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 35;
+export const ENGINE_VERSION = 36;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
  * fix (electron): prevent preload script from overwriting existing ones [#302](https://github.com/cliqz-oss/adblocker/pull/302)