### PR TITLE
feature: new advanced optimization for cosmetic filters (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 *not released*
 
   * simplify reverse index by removing special tokens handling [#333](https://github.com/cliqz-oss/adblocker/pull/333)
+  * feature: new advanced optimization for cosmetic filters (opt-in) [#305](https://github.com/cliqz-oss/adblocker/pull/305)
+
+    > Add new advanced optimization allowing to fusion similar cosmetic
+    > filters internally and transparently. This results in overall memory
+    > saving of `10%` (together with `enableCompression`, savings can go up to
+    > `30%` of memory used).
+    >
+    > This approach has one main drawback: fusion of filters disable the
+    > ability to remove individual filters from the engine; which is why
+    > this feature is disabled by default. If your use-case does not require
+    > updating the engine with `diffs` of filters (added or removed filters)
+    > then it should be safe to use.
 
 ## 1.1.0
 

--- a/packages/adblocker-electron-example/index.ts
+++ b/packages/adblocker-electron-example/index.ts
@@ -24,30 +24,33 @@ async function createWindow() {
     throw new Error('defaultSession is undefined');
   }
 
-  const engine = await ElectronBlocker.fromLists(fetch, fullLists);
-  engine.enableBlockingInSession(session.defaultSession);
+  const blocker = await ElectronBlocker.fromLists(fetch, fullLists, {
+    enableCompression: true,
+    enableDangerousOptimizations: true,
+  });
+  blocker.enableBlockingInSession(session.defaultSession);
 
-  engine.on('request-blocked', (request: Request) => {
+  blocker.on('request-blocked', (request: Request) => {
     console.log('blocked', request.tabId, request.url);
   });
 
-  engine.on('request-redirected', (request: Request) => {
+  blocker.on('request-redirected', (request: Request) => {
     console.log('redirected', request.tabId, request.url);
   });
 
-  engine.on('request-whitelisted', (request: Request) => {
+  blocker.on('request-whitelisted', (request: Request) => {
     console.log('whitelisted', request.tabId, request.url);
   });
 
-  engine.on('csp-injected', (request: Request) => {
+  blocker.on('csp-injected', (request: Request) => {
     console.log('csp', request.url);
   });
 
-  engine.on('script-injected', (script: string, url: string) => {
+  blocker.on('script-injected', (script: string, url: string) => {
     console.log('script', script.length, url);
   });
 
-  engine.on('style-injected', (style: string, url: string) => {
+  blocker.on('style-injected', (style: string, url: string) => {
     console.log('style', style.length, url);
   });
 

--- a/packages/adblocker-puppeteer-example/index.ts
+++ b/packages/adblocker-puppeteer-example/index.ts
@@ -1,9 +1,14 @@
-import { fullLists, PuppeteerBlocker, Request } from '@cliqz/adblocker-puppeteer';
+import { adsAndTrackingLists, PuppeteerBlocker, Request } from '@cliqz/adblocker-puppeteer';
 import fetch from 'node-fetch';
 import puppeteer from 'puppeteer';
 
 (async () => {
-  const blocker = await PuppeteerBlocker.fromLists(fetch, fullLists);
+  const blocker = await PuppeteerBlocker.fromLists(fetch, adsAndTrackingLists, {
+    enableCompression: true,
+    // enableDangerousOptimizations: true,
+  });
+  console.log('SIZE', blocker.serialize().length);
+
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: false,
@@ -33,6 +38,7 @@ import puppeteer from 'puppeteer';
   });
 
   blocker.on('style-injected', (style: string, url: string) => {
+    // console.log(style);
     console.log('style', style.length, url);
   });
 

--- a/packages/adblocker-webextension-example/background.ts
+++ b/packages/adblocker-webextension-example/background.ts
@@ -6,7 +6,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { BlockingResponse, fullLists, Request, WebExtensionBlocker } from '@cliqz/adblocker-webextension';
+import {
+  BlockingResponse,
+  fullLists,
+  Request,
+  WebExtensionBlocker,
+} from '@cliqz/adblocker-webextension';
 
 /**
  * Keep track of number of network requests altered for each tab
@@ -37,20 +42,23 @@ chrome.tabs.onActivated.addListener(({ tabId }: chrome.tabs.TabActiveInfo) =>
   updateBlockedCounter(tabId),
 );
 
-WebExtensionBlocker.fromLists(fetch, fullLists).then((engine: WebExtensionBlocker) => {
-  engine.enableBlockingInBrowser();
-  engine.on('request-blocked', incrementBlockedCounter);
-  engine.on('request-redirected', incrementBlockedCounter);
+WebExtensionBlocker.fromLists(fetch, fullLists, {
+  enableCompression: true,
+  enableDangerousOptimizations: true,
+}).then((blocker: WebExtensionBlocker) => {
+  blocker.enableBlockingInBrowser();
+  blocker.on('request-blocked', incrementBlockedCounter);
+  blocker.on('request-redirected', incrementBlockedCounter);
 
-  engine.on('csp-injected', (request: Request) => {
+  blocker.on('csp-injected', (request: Request) => {
     console.log('csp', request.url);
   });
 
-  engine.on('script-injected', (script: string, url: string) => {
+  blocker.on('script-injected', (script: string, url: string) => {
     console.log('script', script.length, url);
   });
 
-  engine.on('style-injected', (style: string, url: string) => {
+  blocker.on('style-injected', (style: string, url: string) => {
     console.log('style', url, style.length);
   });
 

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -29,7 +29,6 @@ export {
   parseFilter,
   parseFilters,
 } from './src/lists';
-export { compactTokens, hasEmptyIntersection, mergeCompactSets } from './src/compact-set';
 export * from './src/fetch';
 export { tokenize } from './src/utils';
 export { default as Config } from './src/config';

--- a/packages/adblocker/src/compact-set.ts
+++ b/packages/adblocker/src/compact-set.ts
@@ -34,7 +34,17 @@ export function hasEmptyIntersection(s1: Uint32Array, s2: Uint32Array): boolean 
   return !(i < s1.length && j < s2.length);
 }
 
+const EMPTY_UINT32_ARRAY = new Uint32Array(0);
+
 export function concatTypedArrays(arrays: Uint32Array[]): Uint32Array {
+  if (arrays.length === 0) {
+    return EMPTY_UINT32_ARRAY;
+  }
+
+  if (arrays.length === 1) {
+    return arrays[0];
+  }
+
   let totalSize = 0;
   for (let i = 0; i < arrays.length; i += 1) {
     totalSize += arrays[i].length;

--- a/packages/adblocker/src/compact-set.ts
+++ b/packages/adblocker/src/compact-set.ts
@@ -11,8 +11,7 @@ export function compactTokens(tokens: Uint32Array): Uint32Array {
   let lastIndex = 1;
   for (let i = 1; i < sorted.length; i += 1) {
     if (sorted[lastIndex - 1] !== sorted[i]) {
-      sorted[lastIndex] = sorted[i];
-      lastIndex += 1;
+      sorted[lastIndex++] = sorted[i];
     }
   }
 
@@ -26,12 +25,12 @@ export function hasEmptyIntersection(s1: Uint32Array, s2: Uint32Array): boolean 
   while (i < s1.length && j < s2.length && s1[i] !== s2[j]) {
     if (s1[i] < s2[j]) {
       i += 1;
-    } else if (s2[j] < s1[i]) {
+    } else {
       j += 1;
     }
   }
 
-  return !(i < s1.length && j < s2.length);
+  return i === s1.length || j === s2.length;
 }
 
 const EMPTY_UINT32_ARRAY = new Uint32Array(0);
@@ -63,6 +62,6 @@ export function concatTypedArrays(arrays: Uint32Array[]): Uint32Array {
   return result;
 }
 
-export function mergeCompactSets(...arrays: Uint32Array[]): Uint32Array {
+export function mergeCompactSets(arrays: Uint32Array[]): Uint32Array {
   return compactTokens(concatTypedArrays(arrays));
 }

--- a/packages/adblocker/src/config.ts
+++ b/packages/adblocker/src/config.ts
@@ -13,6 +13,7 @@ export default class Config {
     return new Config({
       debug: buffer.getBool(),
       enableCompression: buffer.getBool(),
+      enableDangerousOptimizations: buffer.getBool(),
       enableMutationObserver: buffer.getBool(),
       enableOptimizations: buffer.getBool(),
       integrityCheck: buffer.getBool(),
@@ -24,6 +25,7 @@ export default class Config {
 
   public readonly debug: boolean;
   public readonly enableCompression: boolean;
+  public readonly enableDangerousOptimizations: boolean;
   public readonly enableMutationObserver: boolean;
   public readonly enableOptimizations: boolean;
   public readonly integrityCheck: boolean;
@@ -34,6 +36,7 @@ export default class Config {
   constructor({
     debug = false,
     enableCompression = false,
+    enableDangerousOptimizations = false,
     enableMutationObserver = true,
     enableOptimizations = true,
     integrityCheck = true,
@@ -43,6 +46,7 @@ export default class Config {
   }: Partial<Config> = {}) {
     this.debug = debug;
     this.enableCompression = enableCompression;
+    this.enableDangerousOptimizations = enableDangerousOptimizations;
     this.enableMutationObserver = enableMutationObserver;
     this.enableOptimizations = enableOptimizations;
     this.integrityCheck = integrityCheck;
@@ -54,12 +58,13 @@ export default class Config {
   public getSerializedSize(): number {
     // NOTE: this should always be the number of attributes and needs to be
     // updated when `Config` changes.
-    return 8 * StaticDataView.sizeOfBool();
+    return 9 * StaticDataView.sizeOfBool();
   }
 
   public serialize(buffer: StaticDataView): void {
     buffer.pushBool(this.debug);
     buffer.pushBool(this.enableCompression);
+    buffer.pushBool(this.enableDangerousOptimizations);
     buffer.pushBool(this.enableMutationObserver);
     buffer.pushBool(this.enableOptimizations);
     buffer.pushBool(this.integrityCheck);

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -419,6 +419,7 @@ export default class CosmeticFilterBucket {
     // =======================================================================
     // Id selector based
     // =======================================================================
+    console.log('#IDS', ids.sort(), hashStrings(ids.sort()));
     if (allowGenericHides === true && getRulesFromDOM === true && ids.length !== 0) {
       this.idsIndex.iterMatchingFilters(hashStrings(ids), (rule: CosmeticFilter) => {
         if (rule.match(hostname, domain)) {

--- a/packages/adblocker/src/engine/bucket/network.ts
+++ b/packages/adblocker/src/engine/bucket/network.ts
@@ -10,7 +10,7 @@ import Config from '../../config';
 import StaticDataView from '../../data-view';
 import NetworkFilter from '../../filters/network';
 import Request from '../../request';
-import { noopOptimizeNetwork, optimizeNetwork } from '../optimizer';
+import { noopOptimizeNetwork, optimizeNetwork } from '../optimize/network';
 import ReverseIndex from '../reverse-index';
 import FiltersContainer from './filters';
 

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -70,11 +70,10 @@ export default class FilterEngine extends EventEmitter<
     this: T,
     fetch: Fetch,
     urls: string[],
-    resourcesUrl?: string | undefined,
     config: Partial<Config> = {},
   ): Promise<InstanceType<T>> {
     const listsPromises = fetchLists(fetch, urls);
-    const resourcesPromise = fetchResources(fetch, resourcesUrl);
+    const resourcesPromise = fetchResources(fetch);
 
     return Promise.all([listsPromises, resourcesPromise]).then(([lists, resources]) => {
       const engine = this.parse(lists.join('\n'), config);

--- a/packages/adblocker/src/engine/optimize/cosmetic.ts
+++ b/packages/adblocker/src/engine/optimize/cosmetic.ts
@@ -1,0 +1,124 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { concatTypedArrays } from '../../compact-set';
+import CosmeticFilter from '../../filters/cosmetic';
+import { Optimization, optimize } from './utils';
+
+/**
+ * Optimizer which returns the list of original filters.
+ */
+export function noopOptimizeCosmetic(filters: CosmeticFilter[]): CosmeticFilter[] {
+  return filters;
+}
+
+const OPTIMIZATIONS: Array<Optimization<CosmeticFilter>> = [
+  {
+    description: 'Group cosmetics sharing the same selector',
+    fusion: (filters: CosmeticFilter[]) => {
+      // Aggregate over all filters
+      const entities: Uint32Array[] = [];
+      const hostnames: Uint32Array[] = [];
+      const notEntities: Uint32Array[] = [];
+      const notHostnames: Uint32Array[] = [];
+
+      let rawLine: string | undefined;
+      let onlyNegation = false;
+
+      // Accumulate hostnames/entities for all `filters`
+      for (let i = 0; i < filters.length; i += 1) {
+        const filter = filters[i];
+        // Special case where one of the filters is generic (matches any domain, modulo exceptions)
+        if (filter.entities === undefined && filter.hostnames === undefined) {
+          onlyNegation = true;
+        }
+
+        // Accumulate hostname constraints
+        if (onlyNegation === false) {
+          if (filter.entities !== undefined) {
+            entities.push(filter.entities);
+          }
+
+          if (filter.hostnames !== undefined) {
+            hostnames.push(filter.hostnames);
+          }
+        }
+
+        if (filter.notEntities !== undefined) {
+          notEntities.push(filter.notEntities);
+        }
+
+        if (filter.notHostnames !== undefined) {
+          notHostnames.push(filter.notHostnames);
+        }
+      }
+
+      // If we are in `debug` mode, combine rawLine from all `filters`
+      if (filters[0].rawLine !== undefined) {
+        let firstHashIndex = -1;
+        const rawHosts: string[] = []; // list of hostname constraints
+
+        for (let i = 0; i < filters.length; i += 1) {
+          const filter = filters[i];
+
+          if (filter.rawLine !== undefined) {
+            firstHashIndex = filter.rawLine.indexOf('#');
+            if (firstHashIndex !== 0) {
+              const hosts = filter.rawLine.slice(0, firstHashIndex);
+              const parts: string[] = hosts.split(',');
+              for (let j = 0; j < parts.length; j += 1) {
+                const part = parts[j];
+                if (onlyNegation === false || part.startsWith('~')) {
+                  rawHosts.push(part);
+                }
+              }
+            }
+          }
+        }
+
+        // @ts-ignore
+        rawLine = `${rawHosts.join(',')}${filters[filters.length - 1].rawLine.slice(
+          firstHashIndex,
+        )}`;
+      }
+
+      // console.log('combine', filters.length, filters.map(f => f.toString()), rawLine);
+
+      return new CosmeticFilter({
+        mask: filters[0].mask,
+        selector: filters[0].selector,
+
+        entities:
+          onlyNegation === true || entities.length === 0
+            ? undefined
+            : concatTypedArrays(entities).sort(),
+        hostnames:
+          onlyNegation === true || hostnames.length === 0
+            ? undefined
+            : concatTypedArrays(hostnames).sort(),
+
+        notEntities: notEntities.length === 0 ? undefined : concatTypedArrays(notEntities).sort(),
+        notHostnames:
+          notHostnames.length === 0 ? undefined : concatTypedArrays(notHostnames).sort(),
+
+        style: undefined,
+
+        rawLine,
+      });
+    },
+    groupByCriteria: (filter: CosmeticFilter): string => `${filter.mask}${filter.selector}`,
+    select: (filter: CosmeticFilter): boolean => filter.hasCustomStyle() === false,
+  },
+];
+
+/**
+ * Fusion a set of `filters` by applying optimizations sequentially.
+ */
+export function optimizeCosmetic(filters: CosmeticFilter[]): CosmeticFilter[] {
+  return optimize(OPTIMIZATIONS, filters);
+}

--- a/packages/adblocker/src/engine/optimize/utils.ts
+++ b/packages/adblocker/src/engine/optimize/utils.ts
@@ -41,7 +41,7 @@ function splitBy<T extends Filter>(
 
   for (let i = 0; i < filters.length; i += 1) {
     const filter = filters[i];
-    if (condition(filter)) {
+    if (condition(filter) === true) {
       positive.push(filter);
     } else {
       negative.push(filter);
@@ -68,17 +68,21 @@ export function optimize<T extends Filter>(optimizations: Array<Optimization<T>>
   const fused: T[] = [];
   let toFuse = filters;
 
-  optimizations.forEach(({ select, fusion, groupByCriteria }) => {
+  for (let i = 0; i < optimizations.length; i += 1) {
+    const { select, fusion, groupByCriteria } = optimizations[i];
     const { positive, negative } = splitBy(toFuse, select);
     toFuse = negative;
-    groupBy(positive, groupByCriteria).forEach((group) => {
+
+    const groups = groupBy(positive, groupByCriteria);
+    for (let j = 0; j < groups.length; j += 1) {
+      const group = groups[j];
       if (group.length > 1) {
         fused.push(fusion(group));
       } else {
         toFuse.push(group[0]);
       }
-    });
-  });
+    }
+  }
 
   for (let i = 0; i < toFuse.length; i += 1) {
     fused.push(toFuse[i]);

--- a/packages/adblocker/src/engine/optimize/utils.ts
+++ b/packages/adblocker/src/engine/optimize/utils.ts
@@ -1,0 +1,88 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import Filter from '../../filters/interface';
+
+function setWithDefault<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  let bucket = map.get(key);
+  if (bucket === undefined) {
+    bucket = [];
+    map.set(key, bucket);
+  }
+  bucket.push(value);
+}
+
+function groupBy<T extends Filter>(
+  filters: T[],
+  criteria: (filter: T) => string,
+): T[][] {
+  const grouped: Map<string, T[]> = new Map();
+  for (let i = 0; i < filters.length; i += 1) {
+    const filter = filters[i];
+    setWithDefault(grouped, criteria(filter), filter);
+  }
+  return Array.from(grouped.values());
+}
+
+function splitBy<T extends Filter>(
+  filters: T[],
+  condition: (filter: T) => boolean,
+): {
+  positive: T[];
+  negative: T[];
+} {
+  const positive: T[] = [];
+  const negative: T[] = [];
+
+  for (let i = 0; i < filters.length; i += 1) {
+    const filter = filters[i];
+    if (condition(filter)) {
+      positive.push(filter);
+    } else {
+      negative.push(filter);
+    }
+  }
+
+  return {
+    negative,
+    positive,
+  };
+}
+
+export interface Optimization<T extends Filter> {
+  description: string;
+  groupByCriteria: (filter: T) => string;
+  select: (filter: T) => boolean;
+  fusion: (filters: T[]) => T;
+}
+
+/**
+ * Fusion a set of `filters` by applying optimizations sequentially.
+ */
+export function optimize<T extends Filter>(optimizations: Array<Optimization<T>>, filters: T[]): T[] {
+  const fused: T[] = [];
+  let toFuse = filters;
+
+  optimizations.forEach(({ select, fusion, groupByCriteria }) => {
+    const { positive, negative } = splitBy(toFuse, select);
+    toFuse = negative;
+    groupBy(positive, groupByCriteria).forEach((group) => {
+      if (group.length > 1) {
+        fused.push(fusion(group));
+      } else {
+        toFuse.push(group[0]);
+      }
+    });
+  });
+
+  for (let i = 0; i < toFuse.length; i += 1) {
+    fused.push(toFuse[i]);
+  }
+
+  return fused;
+}

--- a/packages/adblocker/src/engine/reverse-index.ts
+++ b/packages/adblocker/src/engine/reverse-index.ts
@@ -209,7 +209,7 @@ export default class ReverseIndex<T extends IFilter> {
   // loaded in memory and stored in `this.cache`. Before using the bucket, we
   // call `this.optimize(...)` on the list of filters to allow some
   // optimizations to be performed (e.g.: fusion of similar filters, etc.).
-  // Have a look into `./src/engine/optimizer.ts` for examples of such
+  // Have a look into `./src/engine/optimize/` for examples of such
   // optimizations.
   private readonly optimize: (filters: T[]) => T[];
   private readonly config: Readonly<Config>;

--- a/packages/adblocker/test/compact-set.test.ts
+++ b/packages/adblocker/test/compact-set.test.ts
@@ -8,7 +8,7 @@
 
 import { compactTokens, hasEmptyIntersection, mergeCompactSets } from '../src/compact-set';
 
-function a(strings: TemplateStringsArray) {
+function a(strings: TemplateStringsArray): Uint32Array {
   const str = strings.raw[0];
   const array = new Uint32Array(str.length);
   for (let i = 0; i < str.length; i += 1) {
@@ -36,11 +36,11 @@ it('#hasEmptyIntersection', () => {
 });
 
 it('#mergeCompactSets', () => {
-  expect(mergeCompactSets(a``, a``)).toEqual(a``);
-  expect(mergeCompactSets(a``, a`cde`)).toEqual(a`cde`);
-  expect(mergeCompactSets(a`abc`, a``)).toEqual(a`abc`);
-  expect(mergeCompactSets(a`abc`, a`cde`)).toEqual(a`abcde`);
-  expect(mergeCompactSets(a`abc`, a`def`)).toEqual(a`abcdef`);
-  expect(mergeCompactSets(a`cba`, a`cde`)).toEqual(a`abcde`);
-  expect(mergeCompactSets(a`c`, a`b`, a`a`, a`cde`)).toEqual(a`abcde`);
+  expect(mergeCompactSets([a``, a``])).toEqual(a``);
+  expect(mergeCompactSets([a``, a`cde`])).toEqual(a`cde`);
+  expect(mergeCompactSets([a`abc`, a``])).toEqual(a`abc`);
+  expect(mergeCompactSets([a`abc`, a`cde`])).toEqual(a`abcde`);
+  expect(mergeCompactSets([a`abc`, a`def`])).toEqual(a`abcdef`);
+  expect(mergeCompactSets([a`cba`, a`cde`])).toEqual(a`abcde`);
+  expect(mergeCompactSets([a`c`, a`b`, a`a`, a`cde`])).toEqual(a`abcde`);
 });

--- a/packages/adblocker/test/engine/optimize/cosmetic.test.ts
+++ b/packages/adblocker/test/engine/optimize/cosmetic.test.ts
@@ -1,0 +1,53 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { optimizeCosmetic } from '../../../src/engine/optimize/cosmetic';
+import CosmeticFilter from '../../../src/filters/cosmetic';
+
+function c(raw: string): CosmeticFilter {
+  const parsed = CosmeticFilter.parse(raw, true);
+
+  if (parsed === null) {
+    throw new Error(`expected ${raw} not to be null`);
+  }
+
+  return parsed;
+}
+
+function sort(filters: CosmeticFilter[]): CosmeticFilter[] {
+  return filters.sort((f1: CosmeticFilter, f2: CosmeticFilter): number => (f1.rawLine || '').length - (f2.rawLine || '').length);
+}
+
+describe('#optimizeCosmetic', () => {
+  it('handles empty list', () => {
+    expect(optimizeCosmetic([])).toEqual([]);
+  });
+
+  it('handles single filter', () => {
+    const filter = c('foo.com##bar');
+    expect(optimizeCosmetic([filter])).toEqual([filter]);
+  });
+
+  it('merges multiple similar filters', () => {
+    expect(sort(optimizeCosmetic([
+      c('foo.com##bar'),
+      c('~sub.foo.com##bar'),
+      c('##bar'),
+
+      c('#@#bar'),
+      c('bar.com#@#bar'),
+
+      c('foo.com##baz'),
+      c('bar.com##baz'),
+    ]))).toEqual(sort([
+      c('~sub.foo.com##bar'),
+      c('#@#bar'),
+      c('foo.com,bar.com##baz'),
+    ]));
+  });
+});

--- a/packages/adblocker/test/reverse-index.test.ts
+++ b/packages/adblocker/test/reverse-index.test.ts
@@ -8,11 +8,8 @@
 
 import Config from '../src/config';
 import StaticDataView from '../src/data-view';
-import {
-  noopOptimizeCosmetic,
-  noopOptimizeNetwork,
-  optimizeNetwork,
-} from '../src/engine/optimizer';
+import { noopOptimizeCosmetic } from '../src/engine/optimize/cosmetic';
+import { noopOptimizeNetwork, optimizeNetwork } from '../src/engine/optimize/network';
 import ReverseIndex from '../src/engine/reverse-index';
 import CosmeticFilter from '../src/filters/cosmetic';
 import IFilter from '../src/filters/interface';


### PR DESCRIPTION
Add new advanced optimization allowing to fusion similar cosmetic filters internally and transparently. This results in overall memory saving of `10%` (together with `enableCompression`, savings can go up to `30%` of memory used).

This approach has one main drawback: fusion of filters disable the ability to remove individual filters from the engine; which is why this feature is disabled by default. If your use-case does not require updating the engine with `diffs` of filters (added or removed filters) then it should be safe to use.