### PR TITLE
chore: clean-ups and small optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 *not released*
 
-  * simplify reverse index by removing special tokens handling [#333](https://github.com/cliqz-oss/adblocker/pull/333)
+  * chore: clean-ups and small optimizations [#334](https://github.com/cliqz-oss/adblocker/pull/334)
+    * rename `engine` to `blocker` in example projects (consistent naming)
+    * enable on-the-fly compression in example projects
+    * remove unused compact set exports (keep internal only)
+    * remove explicit `resourcesUrl` in `fromLists(...)` (we always use the one served from CDN)
+    * use bare for loops in compact sets and optimization framework
+  * simplify reverse index by removing ad-hoc tokens handling [#333](https://github.com/cliqz-oss/adblocker/pull/333)
 
 ## 1.1.0
 

--- a/packages/adblocker-electron-example/index.ts
+++ b/packages/adblocker-electron-example/index.ts
@@ -24,30 +24,32 @@ async function createWindow() {
     throw new Error('defaultSession is undefined');
   }
 
-  const engine = await ElectronBlocker.fromLists(fetch, fullLists);
-  engine.enableBlockingInSession(session.defaultSession);
+  const blocker = await ElectronBlocker.fromLists(fetch, fullLists, {
+    enableCompression: true,
+  });
+  blocker.enableBlockingInSession(session.defaultSession);
 
-  engine.on('request-blocked', (request: Request) => {
+  blocker.on('request-blocked', (request: Request) => {
     console.log('blocked', request.tabId, request.url);
   });
 
-  engine.on('request-redirected', (request: Request) => {
+  blocker.on('request-redirected', (request: Request) => {
     console.log('redirected', request.tabId, request.url);
   });
 
-  engine.on('request-whitelisted', (request: Request) => {
+  blocker.on('request-whitelisted', (request: Request) => {
     console.log('whitelisted', request.tabId, request.url);
   });
 
-  engine.on('csp-injected', (request: Request) => {
+  blocker.on('csp-injected', (request: Request) => {
     console.log('csp', request.url);
   });
 
-  engine.on('script-injected', (script: string, url: string) => {
+  blocker.on('script-injected', (script: string, url: string) => {
     console.log('script', script.length, url);
   });
 
-  engine.on('style-injected', (style: string, url: string) => {
+  blocker.on('style-injected', (style: string, url: string) => {
     console.log('style', style.length, url);
   });
 

--- a/packages/adblocker-puppeteer-example/index.ts
+++ b/packages/adblocker-puppeteer-example/index.ts
@@ -3,7 +3,9 @@ import fetch from 'node-fetch';
 import puppeteer from 'puppeteer';
 
 (async () => {
-  const blocker = await PuppeteerBlocker.fromLists(fetch, fullLists);
+  const blocker = await PuppeteerBlocker.fromLists(fetch, fullLists, {
+    enableCompression: true,
+  });
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: false,

--- a/packages/adblocker-webextension-example/background.ts
+++ b/packages/adblocker-webextension-example/background.ts
@@ -6,7 +6,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { BlockingResponse, fullLists, Request, WebExtensionBlocker } from '@cliqz/adblocker-webextension';
+import {
+  BlockingResponse,
+  fullLists,
+  Request,
+  WebExtensionBlocker,
+} from '@cliqz/adblocker-webextension';
 
 /**
  * Keep track of number of network requests altered for each tab
@@ -37,22 +42,24 @@ chrome.tabs.onActivated.addListener(({ tabId }: chrome.tabs.TabActiveInfo) =>
   updateBlockedCounter(tabId),
 );
 
-WebExtensionBlocker.fromLists(fetch, fullLists).then((engine: WebExtensionBlocker) => {
-  engine.enableBlockingInBrowser();
-  engine.on('request-blocked', incrementBlockedCounter);
-  engine.on('request-redirected', incrementBlockedCounter);
+WebExtensionBlocker.fromLists(fetch, fullLists, { enableCompression: true }).then(
+  (blocker: WebExtensionBlocker) => {
+    blocker.enableBlockingInBrowser();
+    blocker.on('request-blocked', incrementBlockedCounter);
+    blocker.on('request-redirected', incrementBlockedCounter);
 
-  engine.on('csp-injected', (request: Request) => {
-    console.log('csp', request.url);
-  });
+    blocker.on('csp-injected', (request: Request) => {
+      console.log('csp', request.url);
+    });
 
-  engine.on('script-injected', (script: string, url: string) => {
-    console.log('script', script.length, url);
-  });
+    blocker.on('script-injected', (script: string, url: string) => {
+      console.log('script', script.length, url);
+    });
 
-  engine.on('style-injected', (style: string, url: string) => {
-    console.log('style', url, style.length);
-  });
+    blocker.on('style-injected', (style: string, url: string) => {
+      console.log('style', url, style.length);
+    });
 
-  console.log('Ready to roll!');
-});
+    console.log('Ready to roll!');
+  },
+);

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -29,7 +29,6 @@ export {
   parseFilter,
   parseFilters,
 } from './src/lists';
-export { compactTokens, hasEmptyIntersection, mergeCompactSets } from './src/compact-set';
 export * from './src/fetch';
 export { tokenize } from './src/utils';
 export { default as Config } from './src/config';

--- a/packages/adblocker/src/compact-set.ts
+++ b/packages/adblocker/src/compact-set.ts
@@ -11,8 +11,7 @@ export function compactTokens(tokens: Uint32Array): Uint32Array {
   let lastIndex = 1;
   for (let i = 1; i < sorted.length; i += 1) {
     if (sorted[lastIndex - 1] !== sorted[i]) {
-      sorted[lastIndex] = sorted[i];
-      lastIndex += 1;
+      sorted[lastIndex++] = sorted[i];
     }
   }
 
@@ -26,15 +25,25 @@ export function hasEmptyIntersection(s1: Uint32Array, s2: Uint32Array): boolean 
   while (i < s1.length && j < s2.length && s1[i] !== s2[j]) {
     if (s1[i] < s2[j]) {
       i += 1;
-    } else if (s2[j] < s1[i]) {
+    } else {
       j += 1;
     }
   }
 
-  return !(i < s1.length && j < s2.length);
+  return i === s1.length || j === s2.length;
 }
 
+const EMPTY_UINT32_ARRAY = new Uint32Array(0);
+
 export function concatTypedArrays(arrays: Uint32Array[]): Uint32Array {
+  if (arrays.length === 0) {
+    return EMPTY_UINT32_ARRAY;
+  }
+
+  if (arrays.length === 1) {
+    return arrays[0];
+  }
+
   let totalSize = 0;
   for (let i = 0; i < arrays.length; i += 1) {
     totalSize += arrays[i].length;
@@ -53,6 +62,6 @@ export function concatTypedArrays(arrays: Uint32Array[]): Uint32Array {
   return result;
 }
 
-export function mergeCompactSets(...arrays: Uint32Array[]): Uint32Array {
+export function mergeCompactSets(arrays: Uint32Array[]): Uint32Array {
   return compactTokens(concatTypedArrays(arrays));
 }

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -70,11 +70,10 @@ export default class FilterEngine extends EventEmitter<
     this: T,
     fetch: Fetch,
     urls: string[],
-    resourcesUrl?: string | undefined,
     config: Partial<Config> = {},
   ): Promise<InstanceType<T>> {
     const listsPromises = fetchLists(fetch, urls);
-    const resourcesPromise = fetchResources(fetch, resourcesUrl);
+    const resourcesPromise = fetchResources(fetch);
 
     return Promise.all([listsPromises, resourcesPromise]).then(([lists, resources]) => {
       const engine = this.parse(lists.join('\n'), config);

--- a/packages/adblocker/src/engine/optimizer.ts
+++ b/packages/adblocker/src/engine/optimizer.ts
@@ -168,17 +168,21 @@ export function optimizeNetwork(filters: NetworkFilter[]): NetworkFilter[] {
   const fused: NetworkFilter[] = [];
   let toFuse = filters;
 
-  OPTIMIZATIONS.forEach(({ select, fusion, groupByCriteria }) => {
+  for (let i = 0; i < OPTIMIZATIONS.length; i += 1) {
+    const { select, fusion, groupByCriteria } = OPTIMIZATIONS[i];
     const { positive, negative } = splitBy(toFuse, select);
     toFuse = negative;
-    groupBy(positive, groupByCriteria).forEach((group) => {
+
+    const groups = groupBy(positive, groupByCriteria);
+    for (let j = 0; j < groups.length; j += 1) {
+      const group = groups[j];
       if (group.length > 1) {
         fused.push(fusion(group));
       } else {
         toFuse.push(group[0]);
       }
-    });
-  });
+    }
+  }
 
   for (let i = 0; i < toFuse.length; i += 1) {
     fused.push(toFuse[i]);

--- a/packages/adblocker/src/fetch.ts
+++ b/packages/adblocker/src/fetch.ts
@@ -74,9 +74,6 @@ function getResourcesUrl(fetch: Fetch): Promise<string> {
  * Fetch latest version of uBlock Origin's resources, used to inject scripts in
  * the page or redirect request to data URLs.
  */
-export function fetchResources(fetch: Fetch, resourcesUrl?: string): Promise<string> {
-  return (resourcesUrl === undefined
-    ? getResourcesUrl(fetch)
-    : Promise.resolve(resourcesUrl)
-  ).then((url) => fetchResource(fetch, url));
+export function fetchResources(fetch: Fetch): Promise<string> {
+  return getResourcesUrl(fetch).then(url => fetchResource(fetch, url));
 }

--- a/packages/adblocker/test/compact-set.test.ts
+++ b/packages/adblocker/test/compact-set.test.ts
@@ -8,7 +8,7 @@
 
 import { compactTokens, hasEmptyIntersection, mergeCompactSets } from '../src/compact-set';
 
-function a(strings: TemplateStringsArray) {
+function a(strings: TemplateStringsArray): Uint32Array {
   const str = strings.raw[0];
   const array = new Uint32Array(str.length);
   for (let i = 0; i < str.length; i += 1) {
@@ -36,11 +36,11 @@ it('#hasEmptyIntersection', () => {
 });
 
 it('#mergeCompactSets', () => {
-  expect(mergeCompactSets(a``, a``)).toEqual(a``);
-  expect(mergeCompactSets(a``, a`cde`)).toEqual(a`cde`);
-  expect(mergeCompactSets(a`abc`, a``)).toEqual(a`abc`);
-  expect(mergeCompactSets(a`abc`, a`cde`)).toEqual(a`abcde`);
-  expect(mergeCompactSets(a`abc`, a`def`)).toEqual(a`abcdef`);
-  expect(mergeCompactSets(a`cba`, a`cde`)).toEqual(a`abcde`);
-  expect(mergeCompactSets(a`c`, a`b`, a`a`, a`cde`)).toEqual(a`abcde`);
+  expect(mergeCompactSets([a``, a``])).toEqual(a``);
+  expect(mergeCompactSets([a``, a`cde`])).toEqual(a`cde`);
+  expect(mergeCompactSets([a`abc`, a``])).toEqual(a`abc`);
+  expect(mergeCompactSets([a`abc`, a`cde`])).toEqual(a`abcde`);
+  expect(mergeCompactSets([a`abc`, a`def`])).toEqual(a`abcdef`);
+  expect(mergeCompactSets([a`cba`, a`cde`])).toEqual(a`abcde`);
+  expect(mergeCompactSets([a`c`, a`b`, a`a`, a`cde`])).toEqual(a`abcde`);
 });


### PR DESCRIPTION
* rename `engine` to `blocker` in example projects (consistent naming)
* :rocket: enable on-the-fly compression in example projects
* remove unused compact set exports (keep internal only)
* remove explicit `resourcesUrl` in `fromLists(...)` (we always use the one served from CDN)
* use bare for loops in compact sets and optimization framework