### PR TITLE
Support html filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *not released*
 
+  * feat: support subset of HTML filtering rules (^script:has-text(...)) [#339](https://github.com/cliqz-oss/adblocker/pull/339)
   * feat: add support for 'all' option [#338](https://github.com/cliqz-oss/adblocker/pull/338)
   * feat: add support for 'redirect-rule' option [#337](https://github.com/cliqz-oss/adblocker/pull/337)
   * chore: update local assets + generate compression codebooks [#335](https://github.com/cliqz-oss/adblocker/pull/335)

--- a/packages/adblocker-webextension-example/background.ts
+++ b/packages/adblocker-webextension-example/background.ts
@@ -9,6 +9,7 @@
 import {
   BlockingResponse,
   fullLists,
+  HTMLSelector,
   Request,
   WebExtensionBlocker,
 } from '@cliqz/adblocker-webextension';
@@ -58,6 +59,10 @@ WebExtensionBlocker.fromLists(fetch, fullLists, { enableCompression: true }).the
 
     blocker.on('style-injected', (style: string, url: string) => {
       console.log('style', url, style.length);
+    });
+
+    blocker.on('html-filtered', (htmlSelectors: HTMLSelector[]) => {
+      console.log('html selectors', htmlSelectors);
     });
 
     console.log('Ready to roll!');

--- a/packages/adblocker-webextension/adblocker.test.ts
+++ b/packages/adblocker-webextension/adblocker.test.ts
@@ -65,6 +65,7 @@ describe('#fromWebRequestDetails', () => {
     expect(
       fromWebRequestDetails({
         initiator: 'https://sub.foo.com',
+        requestId: '42',
         tabId: 0,
         type: 'script',
         url: 'https://url',
@@ -79,6 +80,7 @@ describe('#fromWebRequestDetails', () => {
     expect(
       fromWebRequestDetails({
         originUrl: 'https://sub.foo.com',
+        requestId: '42',
         tabId: 0,
         type: 'script',
         url: 'https://url',
@@ -93,6 +95,7 @@ describe('#fromWebRequestDetails', () => {
     expect(
       fromWebRequestDetails({
         documentUrl: 'https://sub.foo.com',
+        requestId: '42',
         tabId: 0,
         type: 'script',
         url: 'https://url',
@@ -107,6 +110,7 @@ describe('#fromWebRequestDetails', () => {
     expect(
       fromWebRequestDetails({
         documentUrl: 'https://sub.soURCE.com',
+        requestId: '42',
         tabId: 0,
         type: 'script',
         url: 'https://sub.url.com',

--- a/packages/adblocker-webextension/adblocker.ts
+++ b/packages/adblocker-webextension/adblocker.ts
@@ -8,13 +8,21 @@
 
 import { parse } from 'tldts-experimental';
 
-import { FiltersEngine, Request, WebRequestType } from '@cliqz/adblocker';
+import {
+  FiltersEngine,
+  HTMLSelector,
+  isUTF8,
+  Request,
+  StreamingHtmlFilter,
+  WebRequestType,
+} from '@cliqz/adblocker';
 import { IBackgroundCallback, IMessageFromBackground } from '@cliqz/adblocker-content';
 
 export interface WebRequestBeforeRequestDetails {
   tabId: number;
   url: string;
   type: WebRequestType;
+  requestId: string;
 
   initiator?: string;
   originUrl?: string;
@@ -66,6 +74,111 @@ export function updateResponseHeadersWithCSP(
   return { responseHeaders };
 }
 
+// From https://github.com/kelseasy/web-ext-types/blob/master/global/index.d.ts#L1897
+interface StreamFilter {
+  error: string;
+  status:
+    | 'uninitialized'
+    | 'transferringdata'
+    | 'finishedtransferringdata'
+    | 'suspended'
+    | 'closed'
+    | 'disconnected'
+    | 'failed';
+
+  onstart: (event: any) => void;
+  ondata: (event: { data: ArrayBuffer }) => void;
+  onstop: (event: any) => void;
+  onerror: (event: any) => void;
+
+  close(): void;
+  disconnect(): void;
+  resume(): void;
+  suspend(): void;
+  write(data: Uint8Array | ArrayBuffer): void;
+}
+
+// Detect charset with UTF-8 encoding from HTML
+const CHARSET_TAG_RE = /<meta charset=['"]utf-8/i;
+const CHARSET_HTTP_EQUIV_RE = /<meta http-equiv="content-type" content="text\/html;charset=utf-8/i;
+
+/**
+ * Check if HTML filtering is possible in this browser. Only Firefox is supported.
+ */
+function isHTMLFilteringSupported(): boolean {
+  // @ts-ignore
+  const browser: any = typeof browser !== 'undefined' ? browser : chrome;
+
+  // Apply HTML filtering is any
+  return (
+    typeof TextDecoder !== 'undefined' &&
+    typeof TextEncoder !== 'undefined' &&
+    browser.webRequest !== undefined &&
+    browser.webRequest.filterResponseData !== undefined
+  );
+}
+
+function filterRequestHTML(details: { requestId: string }, rules: HTMLSelector[]): void {
+  // @ts-ignore
+  const browser: any = typeof browser !== 'undefined' ? browser : chrome;
+
+  // Create filter to observe loading of resource
+  const filter: StreamFilter = browser.webRequest.filterResponseData(details.requestId);
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  const htmlFilter = new StreamingHtmlFilter(rules);
+  let utf8: undefined | boolean;
+
+  filter.ondata = (event) => {
+    let decoded = '';
+    try {
+      // Attempt decoding chunk (ArrayBuffer) into a string.
+      decoded = decoder.decode(event.data, { stream: true });
+    } catch (ex) {
+      // If we fail to decode chunk, then we need to be extra conservative
+      // and we stop listening to streaming response. This is most likely
+      // because we do not support this encoding.
+      filter.write(event.data);
+      filter.disconnect();
+      return;
+    }
+
+    // Try to guess encoding on first chunk received. The assumption is that
+    // we will find either `charset` or `http-equiv` meta-tag in the header.
+    // If none of this is found, then we fallback to using `isUTF8` which
+    // will make sure `event.data` is valid utf-8 (this check is more
+    // costly).
+    if (utf8 === undefined) {
+      utf8 =
+        CHARSET_TAG_RE.test(decoded) ||
+        CHARSET_HTTP_EQUIV_RE.test(decoded) ||
+        isUTF8(new Uint8Array(event.data));
+    }
+
+    // We only proceed to filter this chunk if we could confirm that encoding
+    // if utf-8. Otherwise we simply proxy the data as-is to not risk
+    // breaking the page.
+    if (utf8 === true) {
+      filter.write(encoder.encode(htmlFilter.write(decoded)));
+    } else {
+      filter.write(event.data);
+    }
+  };
+
+  filter.onstop = async () => {
+    // Make sure we push remaining data if any (needed because both `decoder`
+    // and `htmlFilter` can keep a chunk of data internally which would need
+    // extra input to be processed).
+    const remaining = encoder.encode(htmlFilter.write(decoder.decode())) + htmlFilter.flush();
+
+    if (remaining.length !== 0) {
+      filter.write(encoder.encode(remaining));
+    }
+
+    filter.disconnect();
+  };
+}
+
 /**
  * Wrap `FiltersEngine` into a WebExtension-friendly helper class. It exposes
  * methods to interface with WebExtension APIs needed to block ads.
@@ -112,6 +225,17 @@ export class WebExtensionBlocker extends FiltersEngine {
   ): chrome.webRequest.BlockingResponse => {
     const request = fromWebRequestDetails(details);
     if (request.isMainFrame()) {
+      // Here we optionally perform HTML filtering. This can only be done if:
+      // 1. `enableHtmlFiltering` is set to `true`.
+      // 2. `browser.webRequest.filterResponseData` (Firefox only!).
+      // 3. `TextEncoder` and `TextDecoder` are available.
+      if (this.config.enableHtmlFiltering === true && isHTMLFilteringSupported()) {
+        const htmlFilters = this.getHtmlFilters(request);
+        if (htmlFilters.length !== 0) {
+          filterRequestHTML(details, htmlFilters);
+        }
+      }
+
       return {};
     }
 
@@ -136,7 +260,7 @@ export class WebExtensionBlocker extends FiltersEngine {
       details,
       this.getCSPDirectives(fromWebRequestDetails(details)),
     );
-  }
+  };
 
   private onRuntimeMessage = (
     msg: IBackgroundCallback & { action?: string },
@@ -225,7 +349,7 @@ export class WebExtensionBlocker extends FiltersEngine {
         sendResponse(responseFromBackground);
       }
     }
-  }
+  };
 
   private injectStylesWebExtension(
     styles: string,

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -16,7 +16,7 @@ export {
   ElectronRequestType,
   PuppeteerRequestType,
 } from './src/request';
-export { default as CosmeticFilter } from './src/filters/cosmetic';
+export { HTMLSelector, default as CosmeticFilter } from './src/filters/cosmetic';
 export { default as NetworkFilter } from './src/filters/network';
 export {
   IListDiff,
@@ -31,5 +31,7 @@ export {
 } from './src/lists';
 export * from './src/fetch';
 export { tokenize } from './src/utils';
+export { isUTF8 } from './src/encoding';
 export { default as Config } from './src/config';
 export { default as Resources } from './src/resources';
+export { default as StreamingHtmlFilter } from './src/html-filtering';

--- a/packages/adblocker/src/config.ts
+++ b/packages/adblocker/src/config.ts
@@ -13,6 +13,7 @@ export default class Config {
     return new Config({
       debug: buffer.getBool(),
       enableCompression: buffer.getBool(),
+      enableHtmlFiltering: buffer.getBool(),
       enableMutationObserver: buffer.getBool(),
       enableOptimizations: buffer.getBool(),
       integrityCheck: buffer.getBool(),
@@ -24,6 +25,7 @@ export default class Config {
 
   public readonly debug: boolean;
   public readonly enableCompression: boolean;
+  public readonly enableHtmlFiltering: boolean;
   public readonly enableMutationObserver: boolean;
   public readonly enableOptimizations: boolean;
   public readonly integrityCheck: boolean;
@@ -34,6 +36,7 @@ export default class Config {
   constructor({
     debug = false,
     enableCompression = false,
+    enableHtmlFiltering = false,
     enableMutationObserver = true,
     enableOptimizations = true,
     integrityCheck = true,
@@ -43,6 +46,7 @@ export default class Config {
   }: Partial<Config> = {}) {
     this.debug = debug;
     this.enableCompression = enableCompression;
+    this.enableHtmlFiltering = enableHtmlFiltering;
     this.enableMutationObserver = enableMutationObserver;
     this.enableOptimizations = enableOptimizations;
     this.integrityCheck = integrityCheck;
@@ -54,12 +58,13 @@ export default class Config {
   public getSerializedSize(): number {
     // NOTE: this should always be the number of attributes and needs to be
     // updated when `Config` changes.
-    return 8 * StaticDataView.sizeOfBool();
+    return 9 * StaticDataView.sizeOfBool();
   }
 
   public serialize(buffer: StaticDataView): void {
     buffer.pushBool(this.debug);
     buffer.pushBool(this.enableCompression);
+    buffer.pushBool(this.enableHtmlFiltering);
     buffer.pushBool(this.enableMutationObserver);
     buffer.pushBool(this.enableOptimizations);
     buffer.pushBool(this.integrityCheck);

--- a/packages/adblocker/src/encoding.ts
+++ b/packages/adblocker/src/encoding.ts
@@ -1,0 +1,82 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/*!
+ * Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+// From http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+const utf8d = new Uint8Array([
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+  0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+  7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+  8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+  0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+  0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+  0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+  1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+  1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+  1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+]);
+
+function isAscii(bytes: Uint8Array): boolean {
+  if (bytes.length === 0) {
+    return true;
+  }
+
+  for (let i = 0; i < bytes.length; i += 1) {
+    if (bytes[i] > 127) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function isUTF8(bytes: Uint8Array): boolean {
+  if (bytes.length === 0) {
+    return true;
+  }
+
+  if (isAscii(bytes) === true) {
+    return true;
+  }
+
+  let state: number = 0;
+  for (let i = 0; i < bytes.length; i += 1) {
+    const type = utf8d[bytes[i]];
+    state = utf8d[256 + state * 16 + type];
+    if (state === 1 || state === undefined) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -173,6 +173,61 @@ const isValidCss = (() => {
   };
 })();
 
+// NOTE: we currently handle only `script` tags
+export type Tag = 'script';
+export type HTMLSelector = [Tag, [string]];
+
+/**
+ * Unescape strings by removing backslashes.
+ */
+function unescape(str: string): string {
+  return str.replace(/[\\]([^\\])/g, '$1');
+}
+
+export function extractHTMLSelectorFromRule(rule: string): HTMLSelector | undefined {
+  const prefix = 'script:has-text(';
+  const suffix = ')';
+  let foundBackslash = false;
+  if (rule.startsWith(prefix) && rule.endsWith(suffix)) {
+    let depth = 1;
+    let i = prefix.length; // skip opening 'script:has-text('
+    const end = rule.length;
+    let prev = -1; // previous character
+    for (; i < end && depth !== 0; i += 1) {
+      const code = rule.charCodeAt(i);
+
+      if (prev !== 92 /* '\' */) {
+        if (code === 40 /* '(' */) {
+          depth += 1;
+        }
+
+        if (code === 41 /* ')' */) {
+          depth -= 1;
+        }
+      } else {
+        foundBackslash = true; // keep track of this for un-escaping
+      }
+
+      prev = code;
+    }
+
+    // Only consider a pattern if it not a compound one (i.e.:
+    // script:has-text(foo))
+    if (i === end) {
+      return [
+        'script',
+        [
+          foundBackslash === true
+            ? unescape(rule.slice(prefix.length, i - 1))
+            : rule.slice(prefix.length, i - 1),
+        ],
+      ];
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Masks used to store options of cosmetic filters in a bitmask.
  */
@@ -346,21 +401,27 @@ export default class CosmeticFilter implements IFilter {
 
     // Deal with ^script:has-text(...)
     if (
-      line.length - suffixStartIndex > 18 &&
       line.charCodeAt(suffixStartIndex) === 94 /* '^' */ &&
-      fastStartsWithFrom(line, '^script:has-text(', suffixStartIndex)
+      fastStartsWithFrom(line, 'script:has-text(', suffixStartIndex + 1) &&
+      line.charCodeAt(line.length - 1) === 41 /* ')' */
     ) {
       //   ^script:has-text(selector)
-      //                    ^       ^
-      //                    |       |
-      //                    |       |
-      //                    |       scriptSelectorIndexEnd
-      //                    |
-      //                    scriptSelectorIndexStart
-      const scriptSelectorIndexStart = suffixStartIndex + 17;
-      const scriptSelectorIndexEnd = line.length - 1;
+      //    ^                       ^
+      //    |                       |
+      //    |                       |
+      //    |                       scriptSelectorIndexEnd
+      //    |
+      //    scriptSelectorIndexStart
+      //
+      const scriptSelectorIndexStart = suffixStartIndex + 1;
+      const scriptSelectorIndexEnd = line.length;
       mask = setBit(mask, COSMETICS_MASK.htmlFiltering);
       selector = line.slice(scriptSelectorIndexStart, scriptSelectorIndexEnd);
+
+      // Make sure this is a valid selector
+      if (extractHTMLSelectorFromRule(selector) === undefined) {
+        return null;
+      }
     } else if (
       line.length - suffixStartIndex > 4 &&
       line.charCodeAt(suffixStartIndex) === 43 /* '+' */ &&
@@ -416,31 +477,34 @@ export default class CosmeticFilter implements IFilter {
         mask = setBit(mask, COSMETICS_MASK.isUnicode);
       }
 
-      const c0 = selector.charCodeAt(0);
-      const c1 = selector.charCodeAt(1);
-      const c2 = selector.charCodeAt(2);
+      // Classify selector
+      if (getBit(mask, COSMETICS_MASK.htmlFiltering) === false) {
+        const c0 = selector.charCodeAt(0);
+        const c1 = selector.charCodeAt(1);
+        const c2 = selector.charCodeAt(2);
 
-      // Check if we have a specific case of simple selector (id, class or
-      // href) These are the most common filters and will benefit greatly from
-      // a custom dispatch mechanism.
-      if (getBit(mask, COSMETICS_MASK.scriptInject) === false) {
-        if (c0 === 46 /* '.' */ && isSimpleSelector(selector)) {
-          mask = setBit(mask, COSMETICS_MASK.isClassSelector);
-        } else if (c0 === 35 /* '#' */ && isSimpleSelector(selector)) {
-          mask = setBit(mask, COSMETICS_MASK.isIdSelector);
-        } else if (
-          c0 === 97 /* a */ &&
-          c1 === 91 /* '[' */ &&
-          c2 === 104 /* 'h' */ &&
-          isSimpleHrefSelector(selector, 2)
-        ) {
-          mask = setBit(mask, COSMETICS_MASK.isHrefSelector);
-        } else if (
-          c0 === 91 /* '[' */ &&
-          c1 === 104 /* 'h' */ &&
-          isSimpleHrefSelector(selector, 1)
-        ) {
-          mask = setBit(mask, COSMETICS_MASK.isHrefSelector);
+        // Check if we have a specific case of simple selector (id, class or
+        // href) These are the most common filters and will benefit greatly from
+        // a custom dispatch mechanism.
+        if (getBit(mask, COSMETICS_MASK.scriptInject) === false) {
+          if (c0 === 46 /* '.' */ && isSimpleSelector(selector)) {
+            mask = setBit(mask, COSMETICS_MASK.isClassSelector);
+          } else if (c0 === 35 /* '#' */ && isSimpleSelector(selector)) {
+            mask = setBit(mask, COSMETICS_MASK.isIdSelector);
+          } else if (
+            c0 === 97 /* a */ &&
+            c1 === 91 /* '[' */ &&
+            c2 === 104 /* 'h' */ &&
+            isSimpleHrefSelector(selector, 2)
+          ) {
+            mask = setBit(mask, COSMETICS_MASK.isHrefSelector);
+          } else if (
+            c0 === 91 /* '[' */ &&
+            c1 === 104 /* 'h' */ &&
+            isSimpleHrefSelector(selector, 1)
+          ) {
+            mask = setBit(mask, COSMETICS_MASK.isHrefSelector);
+          }
         }
       }
     }
@@ -920,6 +984,10 @@ export default class CosmeticFilter implements IFilter {
 
   public getSelector(): string {
     return this.selector;
+  }
+
+  public getExtendedSelector(): HTMLSelector | undefined {
+    return extractHTMLSelectorFromRule(this.selector);
   }
 
   public isUnhide(): boolean {

--- a/packages/adblocker/src/html-filtering.ts
+++ b/packages/adblocker/src/html-filtering.ts
@@ -1,0 +1,200 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// This module implements an extremely efficient stream HTML filtering engine
+// which is able to consume an HTML document over time and filter part of it
+// using adblocker selectors.
+
+import { HTMLSelector } from './filters/cosmetic';
+
+export function extractTagsFromHtml(
+  html: string,
+  tag: string,
+): [Array<[number, string]>, string, string] {
+  const tags: Array<[number, string]> = [];
+  const prefix = `<${tag}`;
+  const suffix = `</${tag}>`;
+
+  // Keep track of the beginning of current identified tag
+  let index = html.indexOf(prefix);
+  // Keep tracks of index immediately following last extracted tag
+  let endOfLastTag = 0;
+
+  while (index !== -1) {
+    // Find index of end of current tag. If we do not find it, it could be
+    // because it will come in the next chunk and we should try parsing it
+    // again then.
+    const endOfTagIndex = html.indexOf('>', index + prefix.length);
+    if (endOfTagIndex === -1) {
+      return [tags, html.slice(0, index), html.slice(index)];
+    }
+
+    // Handle short tag form <tag/> which will not have a closing tag.
+    if (html.charCodeAt(endOfTagIndex - 1) === 47 /* '/' */) {
+      endOfLastTag = endOfTagIndex + 1;
+      tags.push([index, html.slice(index, endOfLastTag)]);
+    } else {
+      // Find index of closing tag '</tag>'. If we do not find it, again, it
+      // could mean that it will come in next chunk and we need to try parsing
+      // it again with more input.
+      const indexOfClosingTag = html.indexOf(suffix, endOfTagIndex);
+      if (indexOfClosingTag === -1) {
+        return [tags, html.slice(0, index), html.slice(index)];
+      }
+
+      tags.push([index, html.slice(index, indexOfClosingTag + suffix.length)]);
+      endOfLastTag = indexOfClosingTag + suffix.length;
+    }
+
+    index = html.indexOf(prefix, endOfLastTag);
+  }
+
+  // Make sure we consume as much input as possible so that we do not parse the
+  // same portion of HTML again next time and we can stream chunks as early as
+  // possible.
+  //
+  // We check if there is at least one '<' char after the end of the last
+  // extracted tag; this would indicate that the next chunk might contain the
+  // remaining of a valid tag. We then look up to N characters after this '<'
+  // character, where N is the size of 'prefix'. The rational is that if we
+  // reached this part of the code, then it cannot be a match otherwise we
+  // would have returned earlier (from the loop).
+  let lastClosingTagIndex = html.lastIndexOf('>');
+  if (lastClosingTagIndex === -1) {
+    lastClosingTagIndex = endOfLastTag;
+  }
+
+  const indexOfNextTag = html.indexOf('<', lastClosingTagIndex);
+  // If no '<' in the remaining of input, then it means we can count this chunk
+  // as fully parsed (i.e.: next chunk can be parsed independently without
+  // missing a tag which would start in this one).
+  if (indexOfNextTag === -1) {
+    return [tags, html, ''];
+  }
+
+  // In case of a partial tag ending this 'html' chunk. Then check if we have
+  // enough information to discard it already based on the kind of tags we are
+  // looking for.
+  if (
+    html.length - indexOfNextTag >= prefix.length ||
+    prefix.startsWith(html.slice(indexOfNextTag)) === false
+  ) {
+    return [tags, html, ''];
+  }
+
+  return [tags, html.slice(0, indexOfNextTag), html.slice(indexOfNextTag)];
+}
+
+export function extractSelectorsFromRules(selectors: HTMLSelector[]): [string[], RegExp[]] {
+  const patterns: string[] = [];
+  const regexps: RegExp[] = [];
+
+  for (let i = 0; i < selectors.length; i += 1) {
+    const selector = selectors[i][1][0];
+    if (selector !== undefined) {
+      if (selector.charCodeAt(0) === 47 /* '/' */) {
+        if (selector.endsWith('/')) {
+          regexps.push(new RegExp(selector.slice(1, -1)));
+        } else if (selector.endsWith('/i')) {
+          regexps.push(new RegExp(selector.slice(1, -2), 'i'));
+        }
+      } else {
+        patterns.push(selector);
+      }
+    }
+  }
+
+  return [patterns, regexps];
+}
+
+export function selectTagsToRemove(
+  patterns: string[],
+  regexps: RegExp[],
+  tags: Array<[number, string]>,
+): Array<[number, string]> {
+  const toRemove: Array<[number, string]> = [];
+
+  for (let i = 0; i < tags.length; i += 1) {
+    const tag = tags[i];
+    let found = false;
+    for (let j = 0; j < patterns.length; j += 1) {
+      if (tag[1].indexOf(patterns[j]) !== -1) {
+        toRemove.push(tag);
+        found = true;
+        break;
+      }
+    }
+
+    if (found === false) {
+      for (let j = 0; j < regexps.length; j += 1) {
+        if (regexps[j].test(tag[1]) === true) {
+          toRemove.push(tag);
+          break;
+        }
+      }
+    }
+  }
+
+  return toRemove;
+}
+
+export function removeTagsFromHtml(html: string, toRemove: Array<[number, string]>): string {
+  if (toRemove.length === 0) {
+    return html;
+  }
+
+  let filteredHtml = html;
+  toRemove.reverse(); // make sure to remove from last to first tag (preserve indices)
+  for (let i = 0; i < toRemove.length; i += 1) {
+    const [index, tag] = toRemove[i];
+    filteredHtml = filteredHtml.slice(0, index) + filteredHtml.slice(index + tag.length);
+  }
+
+  return filteredHtml;
+}
+
+export default class StreamingHtmlFilter {
+  private buffer: string;
+  private readonly patterns: string[];
+  private readonly regexps: RegExp[];
+
+  constructor(selectors: HTMLSelector[]) {
+    this.buffer = '';
+
+    // Prepare patterns
+    const extracted = extractSelectorsFromRules(selectors);
+    this.patterns = extracted[0];
+    this.regexps = extracted[1];
+  }
+
+  public flush(): string {
+    return this.buffer;
+  }
+
+  public write(chunk: string): string {
+    // If there are no valid selectors, we can directly write `data`.
+    if (this.patterns.length === 0 && this.regexps.length === 0) {
+      return chunk;
+    }
+
+    // Accumulate buffer + new data
+    this.buffer += chunk;
+
+    // Parse tags from `this.buffer`
+    const [tags, parsed, rest] = extractTagsFromHtml(this.buffer, 'script');
+    this.buffer = rest;
+
+    // If no tags were found, just return the parsed version
+    if (tags.length === 0) {
+      return parsed;
+    }
+
+    // Perform tags filtering using `this.patterns` and `this.regexps`.
+    return removeTagsFromHtml(parsed, selectTagsToRemove(this.patterns, this.regexps, tags));
+  }
+}

--- a/packages/adblocker/test/html-filtering.test.ts
+++ b/packages/adblocker/test/html-filtering.test.ts
@@ -1,0 +1,182 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { HTMLSelector } from '../src/filters/cosmetic';
+import {
+  default as StreamingHtmlFilter,
+  extractSelectorsFromRules,
+  extractTagsFromHtml,
+} from '../src/html-filtering';
+
+// NOTE: `doc` is defined at the end of this file.
+
+describe('html-filtering', () => {
+  describe('#extractTagsFromHtml', () => {
+    const tags = (html: string) => extractTagsFromHtml(html, 'script')[0];
+
+    it('extracts all tags', () => {
+      expect(tags('')).toEqual([]);
+      expect(tags('foo')).toEqual([]);
+      expect(tags('<script>bar</script>')).toEqual([[0, '<script>bar</script>']]);
+      expect(tags('foo <script>bar</script>')).toEqual([[4, '<script>bar</script>']]);
+      expect(tags(`
+<!DOCTYPE html> <html lang="en"> <head>
+<script>script1</script>
+<script id="_$cookiemonster"/>
+<script attr=321>console.log("<script>")</script>
+`)).toEqual([
+  [41, '<script>script1</script>'],
+  [66, '<script id="_$cookiemonster"/>'],
+  [97, '<script attr=321>console.log("<script>")</script>'],
+]);
+    });
+
+    it('extracts tags from streamed document', () => {
+      const tags1 = tags(doc);
+      const tags2 = [];
+      let rest = '';
+      let offset = 0;
+      for (let i = 0; i < doc.length; i += 10) {
+        const result = extractTagsFromHtml(rest + doc.slice(i, i + 10), 'script');
+        tags2.push(...result[0].map(([index, tag]) => [index + offset, tag]));
+        offset += result[1].length;
+        rest = result[2];
+      }
+      expect(tags1).toEqual(tags2);
+    });
+
+    describe('consumes as much input as possible', () => {
+      const remains = (html: string) => {
+        const result = extractTagsFromHtml(html, 'script');
+        const parsed = result[1];
+        const rest = result[2];
+        expect(parsed + rest).toEqual(html);
+        return rest;
+      };
+
+      it('handles empty', () => {
+        expect(remains('')).toEqual('');
+      });
+
+      it('handles no tag', () => {
+        expect(remains('foo')).toEqual('');
+      });
+
+      it('handles one tag', () => {
+        expect(remains('foo<script>foo</script>')).toEqual('');
+      });
+
+      const str = 'foo<script>foo</script>foo<tag/><scri></scri><script>foo</script>';
+      it('remains nothing with full tags', () => {
+        expect(remains(str)).toEqual('');
+      });
+
+      it('remains partial', () => {
+        expect(remains('foo <')).toEqual('<');
+        expect(remains('foo <s')).toEqual('<s');
+        expect(remains('foo <sc')).toEqual('<sc');
+        expect(remains('foo <scr')).toEqual('<scr');
+        expect(remains('foo <scri')).toEqual('<scri');
+        expect(remains('foo <scrip')).toEqual('<scrip');
+      });
+
+      // Test all possible partial tags ending the string
+      const tagStartIndex = 45; // start of last <script> tag
+      for (let i = str.length - 1; i >= tagStartIndex; i -= 1) {
+        const partial = str.slice(0, i);
+        it(partial, () => {
+          expect(remains(partial)).toBe(str.slice(tagStartIndex, i));
+        });
+      }
+    });
+  });
+
+  describe('#extractSelectorsFromRules', () => {
+    it('empty', () => {
+      const [patterns, regexps] = extractSelectorsFromRules([]);
+      expect(patterns).toHaveLength(0);
+      expect(regexps).toHaveLength(0);
+    });
+
+    it('parses patterns and regexps', () => {
+      const [patterns, regexps] = extractSelectorsFromRules([
+        ['script', ['foo']],
+        ['script', ['/foo/']],
+        ['script', ['(bar)']],
+        ['script', ['/(bar)/i']],
+      ]);
+      expect(patterns).toEqual(['foo', '(bar)']);
+      expect(regexps).toEqual([/foo/, /(bar)/i]);
+    });
+  });
+
+  describe('#StreamingHtmlFilter', () => {
+    const filter = (html: string, filters: HTMLSelector[]): string => {
+      const stream = new StreamingHtmlFilter(filters);
+
+      // Feed `html` at once
+      const res1 = stream.write(html) + stream.flush();
+
+      // Feed `html` by small chunks
+      let res2 = '';
+      for (let i = 0; i < html.length; i += 10) {
+        res2 += stream.write(html.slice(i, i + 10));
+      }
+      res2 += stream.flush();
+
+      expect(res1).toEqual(res2);
+      return res1;
+    };
+
+    it('handles empty', () => {
+      expect(filter('', [['script', ['foo']]])).toBe('');
+    });
+
+    it('removes tags', () => {
+      expect(filter('<script>foo</script>', [['script', ['foo']]])).toBe('');
+      expect(filter('foo <script>foo</script>bar', [['script', ['foo']]])).toBe('foo bar');
+      expect(filter('foo <script>fOo</script>bar', [['script', ['/foo/']]])).toBe('foo <script>fOo</script>bar');
+      expect(filter('foo <script>fOo</script>bar', [['script', ['/foo/i']]])).toBe('foo bar');
+    });
+
+    it('handles streamed input', () => {
+      expect(filter(doc, [['script', ['bar']]])).toBe(doc);
+      expect(filter(doc, [
+        ['script', ['/supports_TIMING_API/i']], // removes first script
+        ['script', ['head_tag_start']], // removes second script
+        ['script', ['app_html_start']], // removes third script
+        ['script', ['ads_dot_js_fetch_start']], // removes fourth script
+        ['script', ["__perfMark('redux_json_start');"]],
+        ['script', ["__perfMark('js_deps_fetch_start'"]],
+      ])).toBe(`
+<!DOCTYPE html><html lang="en"><head><div id="2x-container"><<script src="https://www.redditstatic.com/desktop2x/js/ads.js"></script><script id="data">window.___r = {"accountManagerModalData":{}},;</script><script defer="" src="https://www.example.com/foo.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/RedesignContentFonts.509eef5d33306bd3b0d5.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/RedesignOldContentFonts.e450653685d17337cac6.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Chat~Governance~Reddit.503ee0c2d353daa60d6e.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Governance~Reddit.7e2adb288af56de67f65.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Poll~Reddit.5f77a82de48fbb3beb21.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~EconHelperActions~Reddit.ae3c9f7d5b30b3be7151.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Reddit.bb2ade21a865dbd52f3f.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/Chat~Governance~Reddit.19024d94a81678cf79e8.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/Governance~Reddit.98e55a3111b273b2f5dd.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/AdminCommunityTopics~Reddit.f091b12b417d6343dc18.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/Reddit.dc10f78afef6b219b26f.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNotesModal~ModListing~afc2720f.c6d86939d4bd0e144927.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Chat~ChatMessageInput~CollectionCommentsPage~CommentsPage~Frontpage~PostCreation~RedesignCha~0aefb917.e6923ac4e90b854a1995.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatMessageInput~ChatPost~CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNot~3a34166c.dab3a37bed364deddf0e.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatPost~CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNotesModal~ModListin~44a849ee.85ccf598d319cc749b92.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CollectionCommentsPage~CommentsPage~Explore~Frontpage~ModListing~ModQueuePages~ModerationPages~Multi~33b955cc.9c1942fb8eb4378e467c.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNotesModal~ModListing~ModQueu~900871b8.509ec80000f4968bb546.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatPost~CollectionCommentsPage~CommentsPage~Frontpage~ModListing~ModQueuePages~ModerationPages~Mult~8849df7b.067fda741fb3f181c83f.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CollectionCommentsPage~CommentsPage~Explore~Frontpage~ModListing~ModQueuePages~ModerationPages~Multi~5f2f5c2a.9e1690590f39e0d92f45.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatPost~CollectionCommentsPage~CommentsPage~Frontpage~ModListing~ModQueuePages~Multireddit~Original~029c3338.33a759111dafa848481d.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CommentsPage.dce215cbd6a2ed7e9969.js"></script></body></html>`);
+    });
+  });
+});
+
+const doc = (`
+<!DOCTYPE html><html lang="en"><head><script>
+          var __SUPPORTS_TIMING_API = typeof performance === 'object' && !!performance.mark && !! performance.measure && !!performance.getEntriesByType;
+          function __perfMark(name) { __SUPPORTS_TIMING_API && performance.mark(name); };
+          var __firstLoaded = false;
+          function __markFirstPostVisible() {
+            if (__firstLoaded) { return; }
+            __firstLoaded = true;
+            __perfMark("first_post_title_image_loaded");
+          }
+        </script><script>
+          __perfMark('head_tag_start');
+        </script><script>
+          __perfMark('app_html_start');
+        </script><div id="2x-container"><<script>
+          __perfMark('ads_dot_js_fetch_start');
+        </script><script src="https://www.redditstatic.com/desktop2x/js/ads.js"></script><script>
+          __perfMark('redux_json_start');
+        </script><script id="data">window.___r = {"accountManagerModalData":{}},;</script><script>
+          __perfMark('js_deps_fetch_start');
+        </script><script defer="" src="https://www.example.com/foo.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/RedesignContentFonts.509eef5d33306bd3b0d5.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/RedesignOldContentFonts.e450653685d17337cac6.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Chat~Governance~Reddit.503ee0c2d353daa60d6e.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Governance~Reddit.7e2adb288af56de67f65.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Poll~Reddit.5f77a82de48fbb3beb21.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~EconHelperActions~Reddit.ae3c9f7d5b30b3be7151.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Reddit.bb2ade21a865dbd52f3f.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/Chat~Governance~Reddit.19024d94a81678cf79e8.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/Governance~Reddit.98e55a3111b273b2f5dd.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/AdminCommunityTopics~Reddit.f091b12b417d6343dc18.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/Reddit.dc10f78afef6b219b26f.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNotesModal~ModListing~afc2720f.c6d86939d4bd0e144927.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/vendors~Chat~ChatMessageInput~CollectionCommentsPage~CommentsPage~Frontpage~PostCreation~RedesignCha~0aefb917.e6923ac4e90b854a1995.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatMessageInput~ChatPost~CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNot~3a34166c.dab3a37bed364deddf0e.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatPost~CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNotesModal~ModListin~44a849ee.85ccf598d319cc749b92.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CollectionCommentsPage~CommentsPage~Explore~Frontpage~ModListing~ModQueuePages~ModerationPages~Multi~33b955cc.9c1942fb8eb4378e467c.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CollectionCommentsPage~CommentsPage~Explore~Frontpage~GovernanceReleaseNotesModal~ModListing~ModQueu~900871b8.509ec80000f4968bb546.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatPost~CollectionCommentsPage~CommentsPage~Frontpage~ModListing~ModQueuePages~ModerationPages~Mult~8849df7b.067fda741fb3f181c83f.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CollectionCommentsPage~CommentsPage~Explore~Frontpage~ModListing~ModQueuePages~ModerationPages~Multi~5f2f5c2a.9e1690590f39e0d92f45.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/ChatPost~CollectionCommentsPage~CommentsPage~Frontpage~ModListing~ModQueuePages~Multireddit~Original~029c3338.33a759111dafa848481d.js"></script><script defer="" src="https://www.redditstatic.com/desktop2x/CommentsPage.dce215cbd6a2ed7e9969.js"></script></body></html>`);


### PR DESCRIPTION
Implement [HTML filtering](https://github.com/gorhill/ublock/wiki/Static-filter-syntax#html-filters). Only `^script:has-text(...)` is currently supported (as this is the only kind of filters seen in the lists so far). It would be fairly easy to extend it to other tags than `script` as well as allowing some chaining.

Because of the reduced scope of this implementation, it was possible to implement the filtering in a streaming fashion. The `StreamingHtmlFilter` class is able to consume and filter chunks of HTML (from `filterResponseData`) on the fly, shallow-parsing tags and removing the ones matching filters very efficiently.

Examples:

- `example.com##^script:has-text(foo bar)` would remove any `<script>` tag containing the string `foo bar` from the main document HTML response, before it is parsed by the browser.
- `example.com##^script:has-text(/foo bar/i)` same, using a `RegExp` with case-insensitive flag.
- `example.com##^script:has-text(/[\w]{,20}/)` normal `RegExps` work as well.
- `example.com##^script:has-text(foo \(bar\))` parentheses should be escaped if they are part of the pattern, this will match `foo (bar)` from `<script>` tags.

TODO:

- [x] Test streaming HTML filter
- [x] Run benchmark