### PR TITLE
fix: cosmetics injection in Electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *not released*
 
+  * fix: cosmetics injection in Electron [#358](https://github.com/cliqz-oss/adblocker/pull/358)
   * removeListener regardless of engine config [#359](https://github.com/cliqz-oss/adblocker/pull/359)
   * feat: support subset of HTML filtering rules (^script:has-text(...)) [#339](https://github.com/cliqz-oss/adblocker/pull/339)
   * feat: add support for 'all' option [#338](https://github.com/cliqz-oss/adblocker/pull/338)

--- a/packages/adblocker-electron/preload.ts
+++ b/packages/adblocker-electron/preload.ts
@@ -123,7 +123,7 @@ if (window === window.top && window.location.href.startsWith('chrome-devtools://
       // all ids and classes in the DOM at this point of time (DOMContentLoaded
       // event). Afterwards, we will rely on the mutation observer to detect
       // changes.
-      // handleNodes(Array.from(window.document.querySelectorAll('[id],[class],[href]')));
+      handleNodes(Array.from(window.document.querySelectorAll('[id],[class],[href]')));
 
       // Start observing mutations to detect new ids and classes which would
       // need to be hidden.


### PR DESCRIPTION
Fixes #354 

For some reason the part which handles the initial DOM on `DOMContentLoaded` event was commented-out. Which means that some rules were not injected as they should.