### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released*
 
+## 1.2.0
+
+*2019-10-01*
+
   * fix: cosmetics injection in Electron [#358](https://github.com/cliqz-oss/adblocker/pull/358)
   * removeListener regardless of engine config [#359](https://github.com/cliqz-oss/adblocker/pull/359)
   * feat: support subset of HTML filtering rules (^script:has-text(...)) [#339](https://github.com/cliqz-oss/adblocker/pull/339)

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Content blockers benchmark",
   "author": {
     "name": "Cliqz"
@@ -25,7 +25,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.1.0",
+    "@cliqz/adblocker": "^1.2.0",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   },

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": {
     "name": "Cliqz"
@@ -78,6 +78,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.1.0"
+    "@cliqz/adblocker-content": "^1.2.0"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -59,7 +59,7 @@
     }
   ],
   "dependencies": {
-    "@cliqz/adblocker-electron": "^1.1.0",
+    "@cliqz/adblocker-electron": "^1.2.0",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker Electron wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.1.0",
-    "@cliqz/adblocker-content": "^1.1.0"
+    "@cliqz/adblocker": "^1.2.0",
+    "@cliqz/adblocker-content": "^1.2.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.89",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -24,7 +24,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^1.1.0",
+    "@cliqz/adblocker-puppeteer": "^1.2.0",
     "node-fetch": "^2.6.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.1.0",
-    "@cliqz/adblocker-content": "^1.1.0",
+    "@cliqz/adblocker": "^1.2.0",
+    "@cliqz/adblocker-content": "^1.2.0",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": {
     "name": "Cliqz"
@@ -84,6 +84,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.1.0"
+    "@cliqz/adblocker-content": "^1.2.0"
   }
 }

--- a/packages/adblocker-webextension-example/background.ts
+++ b/packages/adblocker-webextension-example/background.ts
@@ -43,28 +43,29 @@ chrome.tabs.onActivated.addListener(({ tabId }: chrome.tabs.TabActiveInfo) =>
   updateBlockedCounter(tabId),
 );
 
-WebExtensionBlocker.fromLists(fetch, fullLists, { enableCompression: true }).then(
-  (blocker: WebExtensionBlocker) => {
-    blocker.enableBlockingInBrowser();
-    blocker.on('request-blocked', incrementBlockedCounter);
-    blocker.on('request-redirected', incrementBlockedCounter);
+WebExtensionBlocker.fromLists(fetch, fullLists, {
+  enableCompression: true,
+  enableHtmlFiltering: true,
+}).then((blocker: WebExtensionBlocker) => {
+  blocker.enableBlockingInBrowser();
+  blocker.on('request-blocked', incrementBlockedCounter);
+  blocker.on('request-redirected', incrementBlockedCounter);
 
-    blocker.on('csp-injected', (request: Request) => {
-      console.log('csp', request.url);
-    });
+  blocker.on('csp-injected', (request: Request) => {
+    console.log('csp', request.url);
+  });
 
-    blocker.on('script-injected', (script: string, url: string) => {
-      console.log('script', script.length, url);
-    });
+  blocker.on('script-injected', (script: string, url: string) => {
+    console.log('script', script.length, url);
+  });
 
-    blocker.on('style-injected', (style: string, url: string) => {
-      console.log('style', url, style.length);
-    });
+  blocker.on('style-injected', (style: string, url: string) => {
+    console.log('style', url, style.length);
+  });
 
-    blocker.on('html-filtered', (htmlSelectors: HTMLSelector[]) => {
-      console.log('html selectors', htmlSelectors);
-    });
+  blocker.on('html-filtered', (htmlSelectors: HTMLSelector[]) => {
+    console.log('html selectors', htmlSelectors);
+  });
 
-    console.log('Ready to roll!');
-  },
-);
+  console.log('Ready to roll!');
+});

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": {
     "name": "Cliqz"
@@ -29,8 +29,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^1.1.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^1.1.0"
+    "@cliqz/adblocker-webextension": "^1.2.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.2.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.89",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": {
     "name": "Cliqz"
@@ -50,8 +50,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.1.0",
-    "@cliqz/adblocker-content": "^1.1.0",
+    "@cliqz/adblocker": "^1.2.0",
+    "@cliqz/adblocker-content": "^1.2.0",
     "tldts-experimental": "^5.3.0"
   },
   "contributors": [

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Cliqz adblocker library",
   "author": {
     "name": "Cliqz"


### PR DESCRIPTION
  * fix: cosmetics injection in Electron [#358](https://github.com/cliqz-oss/adblocker/pull/358)
  * removeListener regardless of engine config [#359](https://github.com/cliqz-oss/adblocker/pull/359)
  * feat: support subset of HTML filtering rules (^script:has-text(...)) [#339](https://github.com/cliqz-oss/adblocker/pull/339)
  * feat: add support for 'all' option [#338](https://github.com/cliqz-oss/adblocker/pull/338)
  * feat: add support for 'redirect-rule' option [#337](https://github.com/cliqz-oss/adblocker/pull/337)
  * chore: update local assets + generate compression codebooks [#335](https://github.com/cliqz-oss/adblocker/pull/335)
  * chore: clean-ups and small optimizations [#334](https://github.com/cliqz-oss/adblocker/pull/334)
    * rename `engine` to `blocker` in example projects (consistent naming)
    * enable on-the-fly compression in example projects
    * remove unused compact set exports (keep internal only)
    * remove explicit `resourcesUrl` in `fromLists(...)` (we always use the one served from CDN)
    * use bare for loops in compact sets and optimization framework
  * simplify reverse index by removing ad-hoc tokens handling [#333](https://github.com/cliqz-oss/adblocker/pull/333)

