### PR TITLE
fix: fetching resources.txt from CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 *not released*
 
+## 1.3.1
+
+*2019-10-09*
+
+  * fix: fetching of resources.txt for adblocker [#373](https://github.com/cliqz-oss/adblocker/pull/373)
+  * feat: add new `fromPrebuiltFull(...)` helper to initialize engine [#373](https://github.com/cliqz-oss/adblocker/pull/373)
+
 ## 1.3.0
 
 *2019-10-07*

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Content blockers benchmark",
   "author": {
     "name": "Cliqz"
@@ -25,7 +25,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.0",
+    "@cliqz/adblocker": "^1.3.1",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   },

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": {
     "name": "Cliqz"
@@ -78,6 +78,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.3.0"
+    "@cliqz/adblocker-content": "^1.3.1"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -59,7 +59,7 @@
     }
   ],
   "dependencies": {
-    "@cliqz/adblocker-electron": "^1.3.0",
+    "@cliqz/adblocker-electron": "^1.3.1",
     "electron": "^6.0.1",
     "node-fetch": "^2.6.0",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker Electron wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "electron": "^6.0.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.0",
-    "@cliqz/adblocker-content": "^1.3.0"
+    "@cliqz/adblocker": "^1.3.1",
+    "@cliqz/adblocker-content": "^1.3.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.89",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -24,7 +24,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^1.3.0",
+    "@cliqz/adblocker-puppeteer": "^1.3.1",
     "node-fetch": "^2.6.0",
     "puppeteer": "^1.18.1",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "puppeteer": "^1.18.1"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.0",
-    "@cliqz/adblocker-content": "^1.3.0",
+    "@cliqz/adblocker": "^1.3.1",
+    "@cliqz/adblocker-content": "^1.3.1",
     "@types/puppeteer": "^1.12.4",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": {
     "name": "Cliqz"
@@ -84,6 +84,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.3.0"
+    "@cliqz/adblocker-content": "^1.3.1"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": {
     "name": "Cliqz"
@@ -29,8 +29,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^1.3.0",
-    "@cliqz/adblocker-webextension-cosmetics": "^1.3.0"
+    "@cliqz/adblocker-webextension": "^1.3.1",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.3.1"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.89",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": {
     "name": "Cliqz"
@@ -50,8 +50,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.0",
-    "@cliqz/adblocker-content": "^1.3.0",
+    "@cliqz/adblocker": "^1.3.1",
+    "@cliqz/adblocker-content": "^1.3.1",
     "tldts-experimental": "^5.3.0"
   },
   "contributors": [

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Cliqz adblocker library",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -16,6 +16,7 @@ import {
   fetchLists,
   fetchPrebuilt,
   fetchResources,
+  fullLists,
 } from '../fetch';
 import CosmeticFilter, { HTMLSelector } from '../filters/cosmetic';
 import NetworkFilter from '../filters/network';
@@ -25,7 +26,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 39;
+export const ENGINE_VERSION = 40;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {
@@ -127,6 +128,26 @@ export default class FilterEngine extends EventEmitter<
       .catch(() => {
         console.log('failed downloading pre-built, fallback to fetching lists');
         return this.fromLists(fetchImpl, adsAndTrackingLists) as Promise<InstanceType<T>>;
+      });
+  }
+
+  /**
+   * Same as `fromPrebuiltAdsAndTracking(...)` but also contains annoyances
+   * rules to block things like cookie notices.
+   */
+  public static fromPrebuiltFull<T extends typeof FilterEngine>(
+    this: T,
+    fetchImpl: Fetch = fetch,
+  ): Promise<InstanceType<T>> {
+    return fetchPrebuilt(
+      fetchImpl,
+      'https://cdn.cliqz.com/adblocker/configs/desktop-full/allowed-lists.json',
+      ENGINE_VERSION,
+    )
+      .then((buffer) => this.deserialize(buffer) as InstanceType<T>)
+      .catch(() => {
+        console.log('failed downloading pre-built, fallback to fetching lists');
+        return this.fromLists(fetchImpl, fullLists) as Promise<InstanceType<T>>;
       });
   }
 

--- a/packages/adblocker/src/fetch.ts
+++ b/packages/adblocker/src/fetch.ts
@@ -33,9 +33,10 @@ export function fetchPrebuilt(
 export const adsLists = [
   'https://easylist.to/easylist/easylist.txt',
   'https://pgl.yoyo.org/adservers/serverlist.php?hostformat=adblockplus&showintro=0&mimetype=plaintext',
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt',
+  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt',
   'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/badware.txt',
   'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/filters.txt',
+  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/resource-abuse.txt',
   'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/unbreak.txt',
 
   'https://easylist-downloads.adblockplus.org/easylistgermany.txt',
@@ -49,7 +50,6 @@ export const adsAndTrackingLists = [
 
 export const fullLists = [
   ...adsAndTrackingLists,
-  'https://raw.githubusercontent.com/uBlockOrigin/uAssets/master/filters/annoyances.txt',
   'https://easylist-downloads.adblockplus.org/fanboy-annoyance.txt',
   'https://www.fanboy.co.nz/fanboy-cookiemonster.txt',
 ];
@@ -65,8 +65,10 @@ function getResourcesUrl(fetch: Fetch): Promise<string> {
   return fetch('https://cdn.cliqz.com/adblocker/resources/ublock-resources/metadata.json')
     .then((response) => response.json())
     .then(
-      ({ latestRevision }) =>
-        `https://cdn.cliqz.com/adblocker/resources/ublock-resources/${latestRevision}/list.txt`,
+      ({ revisions }) =>
+        `https://cdn.cliqz.com/adblocker/resources/ublock-resources/${
+          revisions[revisions.length - 1]
+        }/list.txt`,
     );
 }
 
@@ -75,5 +77,5 @@ function getResourcesUrl(fetch: Fetch): Promise<string> {
  * the page or redirect request to data URLs.
  */
 export function fetchResources(fetch: Fetch): Promise<string> {
-  return getResourcesUrl(fetch).then(url => fetchResource(fetch, url));
+  return getResourcesUrl(fetch).then((url) => fetchResource(fetch, url));
 }


### PR DESCRIPTION
Fixes #372 

In this PR I'm also adding a new helper static method to initialize the `fullLists` preset of the adblocker directly:

```js
FiltersEngine.fromPrebuiltFull(fetch);
PuppeteerBlocker.fromPrebuiltFull(fetch);
ElectronBlocker.fromPrebuiltFull(fetch);
WebExtensionBlocker.fromPrebuiltFull(fetch);
```

@Kikobeats