### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 *not released*
 
+## 1.4.0
+
+*2019-11-12*
+
   * fix handling of websocket filters [#388](https://github.com/cliqz-oss/adblocker/pull/388)
   * bump puppeteer to v2 [#386](https://github.com/cliqz-oss/adblocker/pull/386)
   * bump electron to v7 + inject CSS with 'user' origin [#385](https://github.com/cliqz-oss/adblocker/pull/385)

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "1.3.1"
+  "version": "1.4.0"
 }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-benchmarks",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Content blockers benchmark",
   "author": {
     "name": "Cliqz"
@@ -25,7 +25,7 @@
     "adblock-rs": "^0.1.22"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.1",
+    "@cliqz/adblocker": "^1.4.0",
     "jsdom": "^15.1.1",
     "sandboxed-module": "^2.0.3"
   },

--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-circumvention",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker circumvention for Chrome",
   "author": {
     "name": "Cliqz"
@@ -78,6 +78,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.3.1"
+    "@cliqz/adblocker-content": "^1.4.0"
   }
 }

--- a/packages/adblocker-content/package.json
+++ b/packages/adblocker-content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-content",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker library (content-scripts helpers)",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker-electron-example/package.json
+++ b/packages/adblocker-electron-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-electron-example",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -59,7 +59,7 @@
     }
   ],
   "dependencies": {
-    "@cliqz/adblocker-electron": "^1.3.1",
+    "@cliqz/adblocker-electron": "^1.4.0",
     "electron": "^7.0.0",
     "node-fetch": "^2.6.0",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-electron",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker Electron wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "electron": "^7.0.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.1",
-    "@cliqz/adblocker-content": "^1.3.1"
+    "@cliqz/adblocker": "^1.4.0",
+    "@cliqz/adblocker-content": "^1.4.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.91",

--- a/packages/adblocker-puppeteer-example/package.json
+++ b/packages/adblocker-puppeteer-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-puppeteer-example",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -24,7 +24,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-puppeteer": "^1.3.1",
+    "@cliqz/adblocker-puppeteer": "^1.4.0",
     "node-fetch": "^2.6.0",
     "puppeteer": "^2.0.0",
     "ts-node": "^8.3.0"

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-puppeteer",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker Puppeteer wrapper",
   "author": {
     "name": "Cliqz"
@@ -37,8 +37,8 @@
     "puppeteer": "^2.0.0"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.1",
-    "@cliqz/adblocker-content": "^1.3.1",
+    "@cliqz/adblocker": "^1.4.0",
+    "@cliqz/adblocker-content": "^1.4.0",
     "@types/puppeteer": "^1.20.2",
     "tldts-experimental": "^5.3.0"
   },

--- a/packages/adblocker-webextension-cosmetics/package.json
+++ b/packages/adblocker-webextension-cosmetics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension-cosmetics",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Enable cosmetics in WebExtension content blocker using Cliqz adblocker",
   "author": {
     "name": "Cliqz"
@@ -84,6 +84,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.3.1"
+    "@cliqz/adblocker-content": "^1.4.0"
   }
 }

--- a/packages/adblocker-webextension-example/package.json
+++ b/packages/adblocker-webextension-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cliqz/adblocker-webextension-example",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Example of WebExtension adblocker using Cliqz",
   "author": {
     "name": "Cliqz"
@@ -29,8 +29,8 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "dependencies": {
-    "@cliqz/adblocker-webextension": "^1.3.1",
-    "@cliqz/adblocker-webextension-cosmetics": "^1.3.1"
+    "@cliqz/adblocker-webextension": "^1.4.0",
+    "@cliqz/adblocker-webextension-cosmetics": "^1.4.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.91",

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker-webextension",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker WebExtension wrapper",
   "author": {
     "name": "Cliqz"
@@ -50,8 +50,8 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@cliqz/adblocker": "^1.3.1",
-    "@cliqz/adblocker-content": "^1.3.1",
+    "@cliqz/adblocker": "^1.4.0",
+    "@cliqz/adblocker-content": "^1.4.0",
     "tldts-experimental": "^5.3.0"
   },
   "contributors": [

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliqz/adblocker",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Cliqz adblocker library",
   "author": {
     "name": "Cliqz"

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -26,7 +26,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 40;
+export const ENGINE_VERSION = 41;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {


### PR DESCRIPTION
  * fix handling of websocket filters [#388](https://github.com/cliqz-oss/adblocker/pull/388)
  * bump puppeteer to v2 [#386](https://github.com/cliqz-oss/adblocker/pull/386)
  * bump electron to v7 + inject CSS with 'user' origin [#385](https://github.com/cliqz-oss/adblocker/pull/385)