### PR TITLE
webextension: handler for runtime messages now returns a promise

### DIFF
--- a/packages/adblocker-webextension/adblocker.ts
+++ b/packages/adblocker-webextension/adblocker.ts
@@ -360,9 +360,11 @@ export class WebExtensionBlocker extends FiltersEngine {
     sender: chrome.runtime.MessageSender,
     sendResponse: (response?: any) => void,
   ): void => {
-    this.handleRuntimeMessage(msg, sender).then(sendResponse).catch((ex) => {
-      console.error('Error while handling runtime message:', ex);
-    });
+    this.handleRuntimeMessage(msg, sender)
+      .then(sendResponse)
+      .catch((ex) => {
+        console.error('Error while handling runtime message:', ex);
+      });
   };
 
   private async injectStylesWebExtension(
@@ -388,10 +390,7 @@ export class WebExtensionBlocker extends FiltersEngine {
     }
 
     // Abort if `chrome.tabs.insertCSS` is not available.
-    if (
-      chrome.tabs === undefined ||
-      chrome.tabs.insertCSS === undefined
-    ) {
+    if (chrome.tabs === undefined || chrome.tabs.insertCSS === undefined) {
       throw new Error('required "chrome.tabs.insertCSS" is not available');
     }
 


### PR DESCRIPTION
Fixes #387 

Handling of runtime messages involves asynchronous operations (e.g. injection of stylesheets in frames) which are currently not tied to the return value of the handler. This causes two issues:

* The caller cannot wait for a runtime message to be handled.
* If an error occurs, then we cannot inform the caller (and instead a `console.error` is shown).

This PR changes the behavior so that handling of runtime messages returns a promise which can fail. Moreover, different cases of failure now trigger custom error messages so that caller knows why errors are thrown.