### PR TITLE
Implement retry mechanism while fetching resources

### DIFF
--- a/packages/adblocker/src/fetch.ts
+++ b/packages/adblocker/src/fetch.ts
@@ -14,6 +14,12 @@ interface FetchResponse {
 
 export type Fetch = (url: string) => Promise<FetchResponse>;
 
+/**
+ * Built-in fetch helpers can be used to initialize the adblocker from
+ * pre-built presets or raw lists (fetched from multiple sources). In case of
+ * failure (e.g. timeout), the whole process of initialization fails. Timeouts
+ * are not so uncommon, and retrying to fetch usually succeeds.
+ */
 export function fetchWithRetry(fetch: Fetch, url: string): Promise<FetchResponse> {
   let retry = 3;
 

--- a/packages/adblocker/test/fetch.test.ts
+++ b/packages/adblocker/test/fetch.test.ts
@@ -1,0 +1,52 @@
+/*!
+ * Copyright (c) 2017-2019 Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { Fetch, fetchWithRetry } from '../src/fetch';
+
+describe('#fetchWithRetry', () => {
+  const fakeFetchFactory = (numberOfFailures: number): Fetch => {
+    return async (_: string) => {
+      if (numberOfFailures > 0) {
+        numberOfFailures -= 1;
+        throw new Error(`Failed: ${numberOfFailures + 1}`);
+      }
+
+      return {
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(`${numberOfFailures}`),
+      };
+    };
+  };
+
+  it('succeeds on first try', async () => {
+    const response = await fetchWithRetry(fakeFetchFactory(0), 'https://example.com');
+    expect(response.text()).resolves.toEqual('0');
+  });
+
+  it('succeeds on second try', async () => {
+    const response = await fetchWithRetry(fakeFetchFactory(1), 'https://example.com');
+    expect(response.text()).resolves.toEqual('0');
+  });
+
+  it('succeeds on third try', async () => {
+    const response = await fetchWithRetry(fakeFetchFactory(2), 'https://example.com');
+    expect(response.text()).resolves.toEqual('0');
+  });
+
+  it('succeeds on fourth try', async () => {
+    const response = await fetchWithRetry(fakeFetchFactory(3), 'https://example.com');
+    expect(response.text()).resolves.toEqual('0');
+  });
+
+  it('fails on fifth try', async () => {
+    await expect(fetchWithRetry(fakeFetchFactory(4), 'https://example.com')).rejects.toEqual(
+      new Error('Failed: 1'),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #390

Built-in fetch helpers can be used to initialize the adblocker from pre-built presets or raw lists (fetched from multiple sources). In case of failure (e.g. timeout), the whole process of initialization fails. Timeouts are not so uncommon, and retrying to fetch usually succeeds. This PR implements a simple retry-mechanism to make it much more unlikely for initialization of the adblocker to fail.