### PR TITLE
testing: Only run CI on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         node: [10, 12, 13]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
The code from `@cliqz/adblocker` does not depend on the platform at all so it seems wasteful to run all tests on Mac, Window, and Linux. Linux should be enough to ensure that the tests finish successfully.