### PR TITLE
Add support for compound HTML filtering rules

### DIFF
--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -16,7 +16,7 @@ export {
   ElectronRequestType,
   PuppeteerRequestType,
 } from './src/request';
-export { HTMLSelector, default as CosmeticFilter } from './src/filters/cosmetic';
+export { default as CosmeticFilter } from './src/filters/cosmetic';
 export { default as NetworkFilter } from './src/filters/network';
 export {
   FilterType,
@@ -35,4 +35,4 @@ export { tokenize } from './src/utils';
 export { isUTF8 } from './src/encoding';
 export { default as Config } from './src/config';
 export { default as Resources } from './src/resources';
-export { default as StreamingHtmlFilter } from './src/html-filtering';
+export { HTMLSelector, default as StreamingHtmlFilter } from './src/html-filtering';

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -18,7 +18,8 @@ import {
   fetchResources,
   fullLists,
 } from '../fetch';
-import CosmeticFilter, { HTMLSelector } from '../filters/cosmetic';
+import { HTMLSelector } from '../html-filtering';
+import CosmeticFilter from '../filters/cosmetic';
 import NetworkFilter from '../filters/network';
 import { IListDiff, IRawDiff, parseFilters } from '../lists';
 import Request from '../request';

--- a/packages/adblocker/src/html-filtering.ts
+++ b/packages/adblocker/src/html-filtering.ts
@@ -10,13 +10,6 @@
 // which is able to consume an HTML document over time and filter part of it
 // using adblocker selectors.
 
-/**
- * Unescape strings by removing backslashes.
- */
-function unescape(str: string): string {
-  return str.replace(/[\\]([^\\])/g, '$1');
-}
-
 export type HTMLSelector = readonly ['script', readonly string[]];
 
 export function extractHTMLSelectorFromRule(rule: string): HTMLSelector | undefined {
@@ -34,7 +27,6 @@ export function extractHTMLSelectorFromRule(rule: string): HTMLSelector | undefi
   // Prepare for finding one or more ':has-text(' selectors in a row
   while (rule.startsWith(prefix, index)) {
     index += prefix.length;
-    let isSelectorUnescapingNeeded = false;
     let currentParsingDepth = 1;
     const startOfSelectorIndex = index;
     let prev = -1; // previous character
@@ -49,18 +41,12 @@ export function extractHTMLSelectorFromRule(rule: string): HTMLSelector | undefi
         if (code === 41 /* ')' */) {
           currentParsingDepth -= 1;
         }
-      } else {
-        isSelectorUnescapingNeeded = true;
       }
 
       prev = code;
     }
 
-    selectors.push(
-      isSelectorUnescapingNeeded === true
-        ? unescape(rule.slice(startOfSelectorIndex, index - 1))
-        : rule.slice(startOfSelectorIndex, index - 1),
-    );
+    selectors.push(rule.slice(startOfSelectorIndex, index - 1));
   }
 
   if (index !== rule.length) {

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -1406,11 +1406,10 @@ describe('Cosmetic filters', () => {
       test('script:has-text(foo):has-text)', null);
 
       // Real filters
-      test("script:has-text('+'\\x)", ['script', ["'+'x"]]);
-      test("script:has-text('+'\\\\x)", ['script', ["'+'\\x"]]);
+      test("script:has-text('+'\\x)", ['script', ["'+'\\x"]]);
       test('script:has-text(("0x)', ['script', ['("0x']]);
       test('script:has-text((window);)', ['script', ['(window);']]);
-      test('script:has-text(,window\\);)', ['script', [',window);']]);
+      test('script:has-text(,window\\);)', ['script', [',window\\);']]);
       test('script:has-text(/addLinkToCopy/i)', ['script', ['/addLinkToCopy/i']]);
       test('script:has-text(/i10C/i)', ['script', ['/i10C/i']]);
       test('script:has-text(/i10C/)', ['script', ['/i10C/']]);
@@ -1421,6 +1420,13 @@ describe('Cosmetic filters', () => {
       test('script:has-text(a.HTMLImageElement.prototype)', ['script', ['a.HTMLImageElement.prototype']]);
       test('script:has-text(this[atob)', ['script', ['this[atob']]);
       test('script:has-text(}(window);)', ['script', ['}(window);']]);
+      test('script:has-text(/^[\w\W]{1700,3000}$/):has-text(/(\\x\d\w){250}/)', [
+        'script',
+        [
+          '/^[\w\W]{1700,3000}$/',
+          '/(\\x\d\w){250}/',
+        ],
+      ])
 
       // Compound
       test('script:has-text(===):has-text(/[\w\W]{14000}/)', [

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -13,6 +13,7 @@ import CosmeticFilter, {
 import NetworkFilter from '../src/filters/network';
 import { parseFilters } from '../src/lists';
 import { fastHash, hashStrings, tokenizeFilter } from '../src/utils';
+import { HTMLSelector } from '../src/html-filtering';
 
 function h(hostnames: string[]): Uint32Array {
   return new Uint32Array(hostnames.map(hashHostnameBackward));
@@ -1371,47 +1372,64 @@ describe('Cosmetic filters', () => {
     });
 
     describe('get selector', () => {
-      for (const [rule, selector] of [
-        // Fake filters for tests
-        ['script:has-text()', ''],
-        ['script:has-text(a)', 'a'],
-        ['script:has-text(/a/)', '/a/'],
-        ['script:has-text(/a/i)', '/a/i'],
-        ['script:has-text(/a//i)', '/a//i'],
-        ['script:has-text(/a/i/)', '/a/i/'],
-        ['script:has-text(())', '()'],
-        ['script:has-text(((a))', '((a)'],
-
-        // Real filters
-        ["script:has-text('+'\\x)", "'+'x"],
-        ["script:has-text('+'\\\\x)", "'+'\\x"],
-        ['script:has-text(("0x)', '("0x'],
-        ['script:has-text((window);)', '(window);'],
-        ['script:has-text(,window\\);)', ',window);'],
-        ['script:has-text(/addLinkToCopy/i)', '/addLinkToCopy/i'],
-        ['script:has-text(/i10C/i)', '/i10C/i'],
-        ['script:has-text(/i10C/)', '/i10C/'],
-        ['script:has-text(3f87b0eaddd)', '3f87b0eaddd'],
-        ['script:has-text(ADBLOCK)', 'ADBLOCK'],
-        ['script:has-text(Inject=!)', 'Inject=!'],
-        ['script:has-text(String.fromCodePoint)', 'String.fromCodePoint'],
-        ['script:has-text(a.HTMLImageElement.prototype)', 'a.HTMLImageElement.prototype'],
-        ['script:has-text(this[atob)', 'this[atob'],
-        ['script:has-text(}(window);)', '}(window);'],
-
-        // TODO - implement support for chaining
-        // ['script:has-text(===):has-text(/[\w\W]{14000}/)', ''],
-        // ['script:has-text(===):has-text(/[\w\W]{16000}/)', ''],
-      ]) {
+      const test = (rule: string, expected: HTMLSelector | null): void => {
         it(`${rule}`, () => {
           const raw = `##^${rule}`;
           const parsed = CosmeticFilter.parse(raw);
-          expect(parsed).not.toBeNull();
-          if (parsed !== null) {
-            expect(parsed.getExtendedSelector()).toStrictEqual(['script', [selector]]);
+          if (expected === null) {
+            expect(parsed).toBeNull();
+          } else {
+            expect(parsed).not.toBeNull();
+            if (parsed !== null) {
+              expect(parsed.getExtendedSelector()).toStrictEqual(expected);
+            }
           }
         });
-      }
+      };
+
+      // Fake filters for tests
+      test('script:has-text()', ['script', ['']]);
+      test('script:has-text(a)', ['script',  ['a']]);
+      test('script:has-text(/a/)', ['script',  ['/a/']]);
+      test('script:has-text(/a/i)', ['script',  ['/a/i']]);
+      test('script:has-text(/a//i)', ['script',  ['/a//i']]);
+      test('script:has-text(/a/i/)', ['script',  ['/a/i/']]);
+      test('script:has-text(())', ['script',  ['()']]);
+      test('script:has-text(((a))', ['script',  ['((a)']]);
+      test('script:has-text((((()', [
+        'script',
+        ['((((']
+      ]);
+
+      // Invalid filters
+      test('script:has-text(foo):)', null);
+      test('script:has-text(foo):has-text)', null);
+
+      // Real filters
+      test("script:has-text('+'\\x)", ['script', ["'+'x"]]);
+      test("script:has-text('+'\\\\x)", ['script', ["'+'\\x"]]);
+      test('script:has-text(("0x)', ['script', ['("0x']]);
+      test('script:has-text((window);)', ['script', ['(window);']]);
+      test('script:has-text(,window\\);)', ['script', [',window);']]);
+      test('script:has-text(/addLinkToCopy/i)', ['script', ['/addLinkToCopy/i']]);
+      test('script:has-text(/i10C/i)', ['script', ['/i10C/i']]);
+      test('script:has-text(/i10C/)', ['script', ['/i10C/']]);
+      test('script:has-text(3f87b0eaddd)', ['script', ['3f87b0eaddd']]);
+      test('script:has-text(ADBLOCK)', ['script', ['ADBLOCK']]);
+      test('script:has-text(Inject=!)', ['script', ['Inject=!']]);
+      test('script:has-text(String.fromCodePoint)', ['script', ['String.fromCodePoint']]);
+      test('script:has-text(a.HTMLImageElement.prototype)', ['script', ['a.HTMLImageElement.prototype']]);
+      test('script:has-text(this[atob)', ['script', ['this[atob']]);
+      test('script:has-text(}(window);)', ['script', ['}(window);']]);
+
+      // Compound
+      test('script:has-text(===):has-text(/[\w\W]{14000}/)', [
+        'script',
+        [
+          '===',
+          '/[\w\W]{14000}/',
+        ],
+      ]);
     });
   });
 


### PR DESCRIPTION
Support for HTML filtering is currently limited to simple rules of the form `[hostnames]##^script:has-text(<pattern>)`. This pull request adds support for compound rules with multiple selectors such as: `[hostnames]##^script:has-text(<pattern1>):has-text(<pattern1>)`.