### PR TITLE
Add helper to cache adblocker engine

### DIFF
--- a/packages/adblocker-electron-example/index.ts
+++ b/packages/adblocker-electron-example/index.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, session } from 'electron';
 import fetch from 'node-fetch';
+import { promises as fs } from 'fs';
 
 import { ElectronBlocker, fullLists, Request } from '@cliqz/adblocker-electron';
 
@@ -26,7 +27,12 @@ async function createWindow() {
 
   const blocker = await ElectronBlocker.fromLists(fetch, fullLists, {
     enableCompression: true,
+  }, {
+    path: 'engine.bin',
+    read: fs.readFile,
+    write: fs.writeFile,
   });
+
   blocker.enableBlockingInSession(session.defaultSession);
 
   blocker.on('request-blocked', (request: Request) => {

--- a/packages/adblocker-electron/README.md
+++ b/packages/adblocker-electron/README.md
@@ -7,7 +7,7 @@
 * **extremely efficient** adblocker (both in memory usage and raw speed)
 * pure JavaScript implementation
 * first-class support for [Node.js](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker), [WebExtension](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-webextension), [Electron](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) and [Puppeteer](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-puppeteer).
-* effectively blocks all types of ads and tracking
+* efficiently blocks all types of ads and tracking
 * supports cosmetics and scriptlet injection
 * small and minimal (only 64KB minified and gzipped)
 * support most filters: Easylist and uBlock Origin formats
@@ -89,6 +89,22 @@ blocker.disableBlockingInSession(session.defaultSession);
 To avoid having to create the same instance of `ElectronBlocker` all over again,
 you can serialize it to a byte-array which you can store on disk for faster
 loading.
+
+```javascript
+import { ElectronBlocker } from '@cliqz/adblocker-electron';
+import fetch from 'cross-fetch'; // required 'fetch'
+import { promises as fs } from 'fs'; // used for caching
+
+ElectronBlocker.fromPrebuiltAdsAndTracking(fetch, {
+  path: 'engine.bin',
+  read: fs.readFile,
+  write: fs.writeFile,
+}).then((blocker) => {
+  blocker.enableBlockingInSession(session.defaultSession);
+});
+```
+
+Or you can do this manually to control the way caching is done:
 
 ```javascript
 import { ElectronBlocker } from '@cliqz/adblocker-electron';

--- a/packages/adblocker-puppeteer-example/index.ts
+++ b/packages/adblocker-puppeteer-example/index.ts
@@ -1,11 +1,17 @@
 import { fullLists, PuppeteerBlocker, Request } from '@cliqz/adblocker-puppeteer';
 import fetch from 'node-fetch';
 import puppeteer from 'puppeteer';
+import { promises as fs } from 'fs';
 
 (async () => {
   const blocker = await PuppeteerBlocker.fromLists(fetch, fullLists, {
     enableCompression: true,
+  }, {
+    path: 'engine.bin',
+    read: fs.readFile,
+    write: fs.writeFile,
   });
+
   const browser = await puppeteer.launch({
     defaultViewport: null,
     headless: false,

--- a/packages/adblocker-puppeteer/README.md
+++ b/packages/adblocker-puppeteer/README.md
@@ -7,7 +7,7 @@
 * **extremely efficient** adblocker (both in memory usage and raw speed)
 * pure JavaScript implementation
 * first-class support for [Node.js](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker), [WebExtension](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-webextension), [Electron](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-electron) and [Puppeteer](https://github.com/cliqz-oss/adblocker/tree/master/packages/adblocker-puppeteer).
-* effectively blocks all types of ads and tracking
+* efficiently blocks all types of ads and tracking
 * supports cosmetics and scriptlet injection
 * small and minimal (only 64KB minified and gzipped)
 * support most filters: Easylist and uBlock Origin formats
@@ -93,6 +93,26 @@ await blocker.disableBlockingInPage(page);
 To avoid having to create the same instance of `PuppeteerBlocker` all over again,
 you can serialize it to a byte-array which you can store on disk for faster
 loading.
+
+```javascript
+import puppeteer from 'puppeteer';
+import { PuppeteerBlocker } from '@cliqz/adblocker-puppeteer';
+import fetch from 'cross-fetch'; // required 'fetch'
+import { promises as fs } from 'fs'; // used for caching
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+
+PuppeteerBlocker.fromPrebuiltAdsAndTracking(fetch, {
+  path: 'engine.bin',
+  read: fs.readFile,
+  write: fs.writeFile,
+}).then((blocker) => {
+  blocker.enableBlockingInPage(page);
+});
+```
+
+Or you can do this manually to control the way caching is done:
 
 ```javascript
 import { PuppeteerBlocker } from '@cliqz/adblocker-puppeteer';


### PR DESCRIPTION
This PR improves the following methods from adblocker engine/blocker:

* `fromLists`,
* `fromPrebuiltAdsOnly`
* `fromPrebuiltAdsAndTracking`
* `fromPrebuiltFull`

With an extra argument `caching` indicating how to cache the resulting engine for faster loading. By default no caching is performed, but if this argument is specified then the engine initialization will:

1. check if engine is already cached, and use this if available (faster)
2. if engine is not cached or loading fails, initializes from scratch (current behavior)
3. new engine is serialized and written to cache for next time.

Example of how to use it with `@cliqz/adblocker-puppeteer` (API is the same for `@cliqz/adblocker-electron` and `@cliqz/adblocker-webextension`):

```typescript
import puppeteer from 'puppeteer';
import { PuppeteerBlocker } from '@cliqz/adblocker-puppeteer';
import fetch from 'cross-fetch'; // required 'fetch'
import { promises as fs } from 'fs'; // used for caching

const browser = await puppeteer.launch();
const page = await browser.newPage();

PuppeteerBlocker.fromPrebuiltAdsAndTracking(fetch, {
  path: 'engine.bin',
  read: fs.readFile,
  write: fs.writeFile,
}).then((blocker) => {
  blocker.enableBlockingInPage(page);
});
```