### PR TITLE
Target ES6 instead of ES3

### DIFF
--- a/packages/adblocker-circumvention/package.json
+++ b/packages/adblocker-circumvention/package.json
@@ -77,7 +77,6 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "@cliqz/adblocker-content": "^1.7.3",
-    "tslib": "^1.10.0"
+    "@cliqz/adblocker-content": "^1.7.3"
   }
 }

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -39,8 +39,7 @@
   "dependencies": {
     "@cliqz/adblocker": "^1.7.3",
     "@cliqz/adblocker-electron-preload": "^1.7.3",
-    "tldts-experimental": "^5.6.3",
-    "tslib": "^1.10.0"
+    "tldts-experimental": "^5.6.3"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",

--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -40,8 +40,7 @@
     "@cliqz/adblocker": "^1.7.3",
     "@cliqz/adblocker-content": "^1.7.3",
     "@types/puppeteer": "^2.0.0",
-    "tldts-experimental": "^5.6.3",
-    "tslib": "^1.10.0"
+    "tldts-experimental": "^5.6.3"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",

--- a/packages/adblocker-webextension-example/tsconfig.json
+++ b/packages/adblocker-webextension-example/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "dist/cjs/",
-    "declarationDir": "dist/types",
-    "target": "esnext"
+    "declarationDir": "dist/types"
   },
   "references": [
     { "path": "../adblocker-webextension/tsconfig.json" },

--- a/packages/adblocker-webextension/package.json
+++ b/packages/adblocker-webextension/package.json
@@ -50,7 +50,6 @@
     "@cliqz/adblocker": "^1.7.3",
     "@cliqz/adblocker-content": "^1.7.3",
     "tldts-experimental": "^5.6.3",
-    "tslib": "^1.10.0",
     "webextension-polyfill-ts": "^0.12.0"
   },
   "contributors": [

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -95,7 +95,6 @@
     "@remusao/smaz": "^1.7.1",
     "@types/chrome": "^0.0.95",
     "@types/firefox-webext-browser": "^70.0.1",
-    "tldts-experimental": "^5.6.3",
-    "tslib": "^1.10.0"
+    "tldts-experimental": "^5.6.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,12 +2,7 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": true,
-    "target": "ES3",
-    "lib": [
-      "es2015",
-      "es2017",
-      "dom"
-    ],
+    "target": "ES6",
     "allowJs": false,
     "esModuleInterop": true,
     "moduleResolution": "Node",


### PR DESCRIPTION
It's 2020 and ES6 has been around for a while. All features that we need in the code-base are supported by browsers and Node.js (which does not prevent host projects from doing extra transpiling if needed), and benchmarks did not show any speed difference between ES6 and ES3. Moreover:

* We can ditch `tslib` as an explicit dependency
* Bundle size went from 171KB to 162KB (-6%)

This PR will also be the first one to be published using the new `auto` workflow (hopefully).