### PR TITLE
Expose original request details through Request class

### DIFF
--- a/packages/adblocker-electron/adblocker.ts
+++ b/packages/adblocker-electron/adblocker.ts
@@ -20,14 +20,12 @@ process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true';
 /**
  * Create an instance of `Request` from `Electron.OnBeforeRequestDetails`.
  */
-export function fromElectronDetails({
-  id,
-  url,
-  resourceType,
-  referrer,
-  webContentsId,
-}: Electron.OnHeadersReceivedListenerDetails | Electron.OnBeforeRequestListenerDetails): Request {
+export function fromElectronDetails(
+  details: Electron.OnHeadersReceivedListenerDetails | Electron.OnBeforeRequestListenerDetails,
+): Request {
+  const { id, url, resourceType, referrer, webContentsId } = details;
   return Request.fromRawDetails({
+    _originalRequestDetails: details,
     requestId: `${id}`,
     sourceUrl: referrer,
     tabId: webContentsId,
@@ -43,8 +41,7 @@ export class BlockingContext {
   constructor(
     private readonly session: Electron.Session,
     private readonly blocker: ElectronBlocker,
-  ) {
-  }
+  ) {}
 
   public enable(): void {
     if (this.blocker.config.loadNetworkFilters === true) {

--- a/packages/adblocker-puppeteer/adblocker.ts
+++ b/packages/adblocker-puppeteer/adblocker.ts
@@ -22,6 +22,7 @@ export function fromPuppeteerDetails(details: puppeteer.Request): Request {
   const frame = details.frame();
   const sourceUrl = frame !== null ? frame.url() : undefined;
   return Request.fromRawDetails({
+    _originalRequestDetails: details,
     requestId: `${details.resourceType()} ${details.url()} ${sourceUrl}`,
     sourceUrl,
     type: details.resourceType(),

--- a/packages/adblocker-webextension/adblocker.ts
+++ b/packages/adblocker-webextension/adblocker.ts
@@ -42,6 +42,7 @@ type StreamFilter = WebRequest.StreamFilter & {
  */
 export function fromWebRequestDetails(details: OnBeforeRequestDetailsType): Request {
   return Request.fromRawDetails({
+    _originalRequestDetails: details,
     requestId: details.requestId,
     sourceUrl: details.initiator || details.originUrl || details.documentUrl,
     tabId: details.tabId,

--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -70,6 +70,14 @@ export interface IRequestInitialization {
   sourceDomain: string;
 
   type: RequestType;
+
+  // Optional attribute referencing the original request details used to create
+  // the Request instance. This can be for example:
+  // * Electron.OnHeadersReceivedListenerDetails
+  // * Electron.OnBeforeRequestListenerDetails
+  // * puppeteer.Request
+  // * webRequest details
+  _originalRequestDetails: any | undefined;
 }
 
 export default class Request {
@@ -86,6 +94,7 @@ export default class Request {
     sourceHostname,
     sourceDomain,
     type = 'main_frame',
+    _originalRequestDetails,
   }: Partial<IRequestInitialization>): Request {
     url = url.toLowerCase();
 
@@ -116,8 +125,12 @@ export default class Request {
       sourceUrl,
 
       type,
+
+      _originalRequestDetails,
     });
   }
+
+  public readonly _originalRequestDetails: any | undefined;
 
   public readonly type: RequestType;
   public readonly isHttp: boolean;
@@ -153,7 +166,10 @@ export default class Request {
 
     sourceDomain,
     sourceHostname,
+
+    _originalRequestDetails,
   }: IRequestInitialization) {
+    this._originalRequestDetails = _originalRequestDetails;
     this.id = requestId;
     this.tabId = tabId;
     this.type = type;


### PR DESCRIPTION
Closes #483 

The new *optional* `_originalRequestDetails` attribute from Request instances allows to get a reference to the original platform-specific request details (e.g. `puppeteer.Request`, webRequest details, `Electron.OnBeforeRequestListenerDetails`, or `Electron.OnHeadersReceivedListenerDetails`)