### PR TITLE
Fix implicit tslib dependency

### DIFF
--- a/packages/adblocker-circumvention/tsconfig.json
+++ b/packages/adblocker-circumvention/tsconfig.json
@@ -10,5 +10,5 @@
       "path": "../adblocker-content/tsconfig.json"
     }
   ],
-  "include": ["src/**/*.ts", "adblocker.ts"]
+  "include": ["./src/**/*.ts", "./adblocker.ts"]
 }

--- a/packages/adblocker-content/tsconfig.json
+++ b/packages/adblocker-content/tsconfig.json
@@ -5,5 +5,5 @@
     "outDir": "dist/cjs",
     "declarationDir": "dist/types"
   },
-  "include": ["adblocker.ts"]
+  "include": ["./adblocker.ts"]
 }

--- a/packages/adblocker-electron-example/tsconfig.json
+++ b/packages/adblocker-electron-example/tsconfig.json
@@ -9,6 +9,6 @@
     { "path": "../adblocker-electron/tsconfig.json" }
   ],
   "files": [
-    "index.ts"
+    "./index.ts"
   ]
 }

--- a/packages/adblocker-electron-preload/tsconfig.json
+++ b/packages/adblocker-electron-preload/tsconfig.json
@@ -10,6 +10,6 @@
     { "path": "../adblocker-content/tsconfig.json" }
   ],
   "files": [
-    "preload.ts"
+    "./preload.ts"
   ]
 }

--- a/packages/adblocker-electron/tsconfig.json
+++ b/packages/adblocker-electron/tsconfig.json
@@ -10,6 +10,6 @@
     { "path": "../adblocker-electron-preload/tsconfig.json" }
   ],
   "files": [
-    "adblocker.ts"
+    "./adblocker.ts"
   ]
 }

--- a/packages/adblocker-puppeteer-example/tsconfig.json
+++ b/packages/adblocker-puppeteer-example/tsconfig.json
@@ -9,6 +9,6 @@
     { "path": "../adblocker-puppeteer/tsconfig.json" }
   ],
   "files": [
-    "index.ts"
+    "./index.ts"
   ]
 }

--- a/packages/adblocker-webextension-example/tsconfig.json
+++ b/packages/adblocker-webextension-example/tsconfig.json
@@ -10,7 +10,7 @@
     { "path": "../adblocker-webextension-cosmetics/tsconfig.json" }
   ],
   "files": [
-    "background.ts",
-    "content-script.ts"
+    "./background.ts",
+    "./content-script.ts"
   ]
 }

--- a/packages/adblocker-webextension/tsconfig.json
+++ b/packages/adblocker-webextension/tsconfig.json
@@ -10,7 +10,7 @@
     { "path": "../adblocker-content/tsconfig.json" }
   ],
   "include": [
-    "src/**/*.ts",
-    "adblocker.ts"
+    "./src/**/*.ts",
+    "./adblocker.ts"
   ]
 }

--- a/packages/adblocker/tsconfig.json
+++ b/packages/adblocker/tsconfig.json
@@ -6,7 +6,7 @@
     "declarationDir": "dist/types"
   },
   "include": [
-    "src/**/*.ts",
-    "adblocker.ts"
+    "./src/**/*.ts",
+    "./adblocker.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,17 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "sourceMap": true,
-    "target": "ES6",
-    "allowJs": false,
-    "esModuleInterop": true,
-    "moduleResolution": "Node",
+    "target": "es6",
     "module": "commonjs",
-    "importHelpers": true,
-    "downlevelIteration": true,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "forceConsistentCasingInFileNames": true,
-    "keyofStringsOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true,
-    "noImplicitThis": true,
+    "moduleResolution": "node",
+    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strict": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true
-  },
-  "exclude": [
-    "node_modules"
-  ]
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "forceConsistentCasingInFileNames": true
+  }
 }


### PR DESCRIPTION
When moving to the new `es6` target of TypeScript, I forgot to remove the `importHelpers` option as well, which still required `tslib` in some files.