### PR TITLE
Move BlockingContext methods back into Blocker class.

### DIFF
--- a/packages/adblocker-electron/adblocker.ts
+++ b/packages/adblocker-electron/adblocker.ts
@@ -38,10 +38,33 @@ export function fromElectronDetails(
  * This abstraction takes care of blocking in one instance of `Electron.Session`.
  */
 export class BlockingContext {
+  private readonly onBeforeRequest: (
+    details: Electron.OnBeforeRequestListenerDetails,
+    callback: (a: Electron.Response) => void,
+  ) => void;
+
+  private readonly onGetCosmeticFilters: (
+    event: Electron.IpcMainEvent,
+    url: string,
+    msg: IBackgroundCallback,
+  ) => void;
+
+  private readonly onHeadersReceived: (
+    details: Electron.OnHeadersReceivedListenerDetails,
+    callback: (a: Electron.HeadersReceivedResponse) => void,
+  ) => void;
+
+  private readonly onIsMutationObserverEnabled: (event: Electron.IpcMainEvent) => void;
+
   constructor(
     private readonly session: Electron.Session,
     private readonly blocker: ElectronBlocker,
-  ) {}
+  ) {
+    this.onBeforeRequest = (details, callback) => blocker.onBeforeRequest(details, callback);
+    this.onGetCosmeticFilters = (event, url, msg) => blocker.onGetCosmeticFilters(event, url, msg);
+    this.onHeadersReceived = (details, callback) => blocker.onHeadersReceived(details, callback);
+    this.onIsMutationObserverEnabled = (event) => blocker.onIsMutationObserverEnabled(event);
+  }
 
   public enable(): void {
     if (this.blocker.config.loadNetworkFilters === true) {
@@ -76,12 +99,56 @@ export class BlockingContext {
       ipcMain.removeListener('is-mutation-observer-enabled', this.onIsMutationObserverEnabled);
     }
   }
+}
 
-  private onIsMutationObserverEnabled = (event: Electron.IpcMainEvent) => {
-    event.returnValue = this.blocker.config.enableMutationObserver;
+/**
+ * Wrap `FiltersEngine` into a Electron-friendly helper class. It exposes
+ * methods to interface with Electron APIs needed to block ads.
+ */
+export class ElectronBlocker extends FiltersEngine {
+  private readonly contexts: WeakMap<Electron.Session, BlockingContext> = new Map();
+
+  // ----------------------------------------------------------------------- //
+  // Helpers to enable and disable blocking for 'browser'
+  // ----------------------------------------------------------------------- //
+
+  public enableBlockingInSession(session: Electron.Session): BlockingContext {
+    let context: undefined | BlockingContext = this.contexts.get(session);
+    if (context !== undefined) {
+      return context;
+    }
+
+    // Create new blocking context for `session`
+    context = new BlockingContext(session, this);
+    this.contexts.set(session, context);
+    context.enable();
+
+    return context;
+  }
+
+  public disableBlockingInSession(session: Electron.Session): void {
+    const context: undefined | BlockingContext = this.contexts.get(session);
+    if (context === undefined) {
+      throw new Error('Trying to disable blocking which was not enabled');
+    }
+
+    this.contexts.delete(session);
+    context.disable();
+  }
+
+  public isBlockingEnabled(session: Electron.Session): boolean {
+    return this.contexts.has(session);
+  }
+
+  // ----------------------------------------------------------------------- //
+  // ElectronBlocker-specific additions to FiltersEngine
+  // ----------------------------------------------------------------------- //
+
+  public onIsMutationObserverEnabled = (event: Electron.IpcMainEvent): void => {
+    event.returnValue = this.config.enableMutationObserver;
   };
 
-  private onGetCosmeticFilters = (
+  public onGetCosmeticFilters = (
     event: Electron.IpcMainEvent,
     url: string,
     msg: IBackgroundCallback,
@@ -91,7 +158,7 @@ export class BlockingContext {
     const hostname = parsed.hostname || '';
     const domain = parsed.domain || '';
 
-    const { active, styles, scripts } = this.blocker.getCosmeticsFilters({
+    const { active, styles, scripts } = this.getCosmeticsFilters({
       domain,
       hostname,
       url,
@@ -125,7 +192,7 @@ export class BlockingContext {
     } as IMessageFromBackground);
   };
 
-  private onHeadersReceived = (
+  public onHeadersReceived = (
     details: Electron.OnHeadersReceivedListenerDetails,
     callback: (a: Electron.HeadersReceivedResponse) => void,
   ): void => {
@@ -134,9 +201,7 @@ export class BlockingContext {
     const responseHeaders: Record<string, string[]> = details.responseHeaders || {};
 
     if (details.resourceType === 'mainFrame' || details.resourceType === 'subFrame') {
-      const rawCSP: string | undefined = this.blocker.getCSPDirectives(
-        fromElectronDetails(details),
-      );
+      const rawCSP: string | undefined = this.getCSPDirectives(fromElectronDetails(details));
       if (rawCSP !== undefined) {
         policies.push(...rawCSP.split(';').map((csp) => csp.trim()));
 
@@ -158,7 +223,7 @@ export class BlockingContext {
     callback({});
   };
 
-  private onBeforeRequest = (
+  public onBeforeRequest = (
     details: Electron.OnBeforeRequestListenerDetails,
     callback: (a: Electron.Response) => void,
   ): void => {
@@ -168,7 +233,7 @@ export class BlockingContext {
       return;
     }
 
-    const { redirect, match } = this.blocker.match(request);
+    const { redirect, match } = this.match(request);
 
     if (redirect) {
       callback({ redirectURL: redirect.dataUrl });
@@ -185,42 +250,6 @@ export class BlockingContext {
         cssOrigin: 'user',
       });
     }
-  }
-}
-
-/**
- * Wrap `FiltersEngine` into a Electron-friendly helper class. It exposes
- * methods to interface with Electron APIs needed to block ads.
- */
-export class ElectronBlocker extends FiltersEngine {
-  private readonly contexts: WeakMap<Electron.Session, BlockingContext> = new Map();
-
-  public enableBlockingInSession(session: Electron.Session): BlockingContext {
-    let context: undefined | BlockingContext = this.contexts.get(session);
-    if (context !== undefined) {
-      return context;
-    }
-
-    // Create new blocking context for `session`
-    context = new BlockingContext(session, this);
-    this.contexts.set(session, context);
-    context.enable();
-
-    return context;
-  }
-
-  public disableBlockingInSession(session: Electron.Session): void {
-    const context: undefined | BlockingContext = this.contexts.get(session);
-    if (context === undefined) {
-      throw new Error('Trying to disable blocking which was not enabled');
-    }
-
-    this.contexts.delete(session);
-    context.disable();
-  }
-
-  public isBlockingEnabled(session: Electron.Session): boolean {
-    return this.contexts.has(session);
   }
 }
 


### PR DESCRIPTION
The intent of moving methods from Blocker classes into a BlockingContext
class was to allow enabling blocking into different contexts (e.g.
multiple Puppeteer pages or Electron sessions). The issue is that it
broke some cases where we want to re-use the methods from Blocker class
without using the 'enableBlockingInX' helper. Also, moving the methods
is not necessary to achieve the initial goal. Instead, the
BlockingContext class simply takes care of registering listeners using
bound versions of Blocker instance to allow unload.