### PR TITLE
Make id of fuzzy filters invariant under permutations

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -27,7 +27,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 80;
+export const ENGINE_VERSION = 81;
 
 // Polyfill for `btoa`
 function btoaPolyfill(buffer: string): string {

--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -261,6 +261,7 @@ function computeFilterId(
   optDomains: Uint32Array | undefined,
   optNotDomains: Uint32Array | undefined,
   redirect: string | undefined,
+  fuzzy: Uint32Array | undefined,
 ): number {
   let hash = (5408 * 33) ^ mask;
 
@@ -297,6 +298,12 @@ function computeFilterId(
   if (redirect !== undefined) {
     for (let i = 0; i < redirect.length; i += 1) {
       hash = (hash * 33) ^ redirect.charCodeAt(i);
+    }
+  }
+
+  if (fuzzy !== undefined) {
+    for (let i = 0; i < fuzzy.length; i += 1) {
+      hash = (hash * 33) ^ fuzzy[i];
     }
   }
 
@@ -1178,11 +1185,12 @@ export default class NetworkFilter implements IFilter {
     return computeFilterId(
       this.csp,
       this.mask & ~NETWORK_FILTER_MASK.isBadFilter,
-      this.filter,
+      this.isFuzzy() ? undefined : this.filter,
       this.hostname,
       this.optDomains,
       this.optNotDomains,
       this.redirect,
+      this.isFuzzy() ? this.getFuzzySignature() : undefined,
     );
   }
 
@@ -1191,11 +1199,12 @@ export default class NetworkFilter implements IFilter {
       this.id = computeFilterId(
         this.csp,
         this.mask,
-        this.filter,
+        this.isFuzzy() ? undefined : this.filter,
         this.hostname,
         this.optDomains,
         this.optNotDomains,
         this.redirect,
+        this.isFuzzy() ? this.getFuzzySignature() : undefined,
       );
     }
     return this.id;

--- a/packages/adblocker/test/parsing.test.ts
+++ b/packages/adblocker/test/parsing.test.ts
@@ -1709,6 +1709,19 @@ describe('Cosmetic filters', () => {
   });
 });
 
+describe('#getId', () => {
+  it('for fuzzy filter is insensitive to permutations', () => {
+    const f1 = NetworkFilter.parse('foo bar baz$fuzzy');
+    const f2 = NetworkFilter.parse('baz bar foo$fuzzy');
+    expect(f1).not.toBeNull();
+    expect(f2).not.toBeNull();
+    if (f1 !== null && f2 !== null) {
+      expect(f1.getId()).toBe(f2.getId());
+      expect(f1.getIdWithoutBadFilter()).toBe(f2.getIdWithoutBadFilter());
+    }
+  });
+});
+
 describe('Filters list', () => {
   it('ignores comments', () => {
     [


### PR DESCRIPTION
# What Changed

With this change, `id` (as returned by `getId()` of `NetworkFilter` instances) for `$fuzzy` filters are invariant under permutation of tokens in their pattern. The following filters will have the same `id`:

* `foo bar baz$fuzzy`,
* `bar foo baz$fuzzy`,
* etc.