### PR TITLE
Fix PuppeteerBlocker and enable blocking of frames and DOM monitoring.

### DIFF
--- a/packages/adblocker-content/adblocker.ts
+++ b/packages/adblocker-content/adblocker.ts
@@ -121,12 +121,12 @@ export class DOMMonitor {
   private observer: MutationObserver | null = null;
 
   constructor(
-    window: Window,
     private readonly cb: (features: { ids: string[]; classes: string[]; hrefs: string[] }) => void,
-  ) {
+  ) {}
+
+  public queryAll(window: Window): void {
     this.handleNewNodes(Array.from(window.document.querySelectorAll('[id],[class],[href]')));
   }
-
   public start(window: Window & { MutationObserver?: typeof MutationObserver }): void {
     if (this.observer === null && window.MutationObserver !== undefined) {
       this.observer = new window.MutationObserver((mutations: MutationRecord[]) => {
@@ -149,8 +149,15 @@ export class DOMMonitor {
     }
   }
 
-  private handleNewNodes(nodes: DOMElement[]): void {
-    const { classes, ids, hrefs } = extractFeaturesFromDOM(nodes);
+  public handleNewFeatures({
+    hrefs,
+    ids,
+    classes,
+  }: {
+    hrefs: string[];
+    ids: string[];
+    classes: string[];
+  }): boolean {
     const newIds: string[] = [];
     const newClasses: string[] = [];
     const newHrefs: string[] = [];
@@ -186,7 +193,14 @@ export class DOMMonitor {
         hrefs: newHrefs,
         ids: newIds,
       });
+      return true;
     }
+
+    return false;
+  }
+
+  private handleNewNodes(nodes: DOMElement[]): boolean {
+    return this.handleNewFeatures(extractFeaturesFromDOM(nodes));
   }
 }
 

--- a/packages/adblocker-electron-preload/preload.ts
+++ b/packages/adblocker-electron-preload/preload.ts
@@ -56,7 +56,7 @@ if (window === window.top && window.location.href.startsWith('devtools://') === 
     window.addEventListener(
       'DOMContentLoaded',
       () => {
-        DOM_MONITOR = new DOMMonitor(window, ({ classes, ids, hrefs }) => {
+        DOM_MONITOR = new DOMMonitor(({ classes, ids, hrefs }) => {
           getCosmeticsFilters({
             classes,
             hrefs,
@@ -64,6 +64,8 @@ if (window === window.top && window.location.href.startsWith('devtools://') === 
             lifecycle: 'dom-update',
           });
         });
+
+        DOM_MONITOR.queryAll(window);
 
         // Start observing mutations to detect new ids and classes which would
         // need to be hidden.

--- a/packages/adblocker-puppeteer-example/index.ts
+++ b/packages/adblocker-puppeteer-example/index.ts
@@ -3,6 +3,15 @@ import fetch from 'node-fetch';
 import * as puppeteer from 'puppeteer';
 import { promises as fs } from 'fs';
 
+function getUrlToLoad(): string {
+  let url = 'https://www.mangareader.net/';
+  if (process.argv[process.argv.length - 1].endsWith('.ts') === false) {
+    url = process.argv[process.argv.length - 1];
+  }
+
+  return url;
+}
+
 (async () => {
   const blocker = await PuppeteerBlocker.fromLists(fetch, fullLists, {
     enableCompression: true,
@@ -44,5 +53,5 @@ import { promises as fs } from 'fs';
     console.log('style', style.length, url);
   });
 
-  await page.goto('https://www.mangareader.net/');
+  await page.goto(getUrlToLoad());
 })();

--- a/packages/adblocker-webextension-cosmetics/adblocker.ts
+++ b/packages/adblocker-webextension-cosmetics/adblocker.ts
@@ -125,7 +125,7 @@ export function injectCosmetics(
   window.addEventListener(
     'DOMContentLoaded',
     () => {
-      DOM_MONITOR = new DOMMonitor(window, ({ classes, ids, hrefs }) => {
+      DOM_MONITOR = new DOMMonitor(({ classes, ids, hrefs }) => {
         getCosmeticsFilters({
           classes,
           hrefs,
@@ -133,6 +133,8 @@ export function injectCosmetics(
           lifecycle: 'dom-update',
         }).then((response) => handleResponseFromBackground(window, response));
       });
+
+      DOM_MONITOR.queryAll(window);
 
       // Start observing mutations to detect new ids and classes which would
       // need to be hidden.


### PR DESCRIPTION
# What Changed

* Fix injection of cosmetics in main frame.
* Allow DOM monitoring.
* Allow to identify and remove advertisement iframes.

Fixes #683

## Release Notes

PuppeteerBlocker is now more powerful and will be able to better block ads on most websites. Firstly, a bug was fixed which prevented injection of cosmetics in the main frame of pages. Secondly, PuppeteerBlocker will now monitor the DOM for changes to make sure that ads which load later
are still "handled" (if you know what I mean). Lastly, PuppeteerBlocker is now able to look for advertisement iframes and remove them from the DOM completely, no more blank spaces left unattended...