### PR TITLE
Correctly redirect to binary resources in puppeteer blocker

### DIFF
--- a/packages/adblocker-puppeteer/adblocker.ts
+++ b/packages/adblocker-puppeteer/adblocker.ts
@@ -282,11 +282,17 @@ export class PuppeteerBlocker extends FiltersEngine {
     const { redirect, match } = this.match(request);
 
     if (redirect !== undefined) {
-      const { body, contentType } = redirect;
-      details.respond({
-        body,
-        contentType,
-      });
+      if (redirect.contentType.endsWith(';base64')) {
+        details.respond({
+          body: Buffer.from(redirect.body, 'base64'),
+          contentType: redirect.contentType.slice(0, -7),
+        });
+      } else {
+        details.respond({
+          body: redirect.body,
+          contentType: redirect.contentType,
+        });
+      }
     } else if (match === true) {
       details.abort('blockedbyclient');
     } else {


### PR DESCRIPTION
# What Changed

Puppeteer expects a `Buffer` instance whenever we want to `respond` to a request with a binary resource. Instead of relying on data URLs like for Electron and WebExtension blockers, we now decode resources to `Buffer` instances based on their content type.