### PR TITLE
Fix domain options with subdomains and more...

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  pull_request:
   push:
     branches: ["master"]
 

--- a/packages/adblocker-content/rollup.config.ts
+++ b/packages/adblocker-content/rollup.config.ts
@@ -18,5 +18,8 @@ export default {
     name: 'adblocker',
     sourcemap: true,
   },
-  plugins: [resolve(), sourcemaps(), compiler()],
+  plugins: [resolve(), sourcemaps(), compiler({
+    // language: 'ECMASCRIPT6_STRICT',
+    language_out: 'NO_TRANSPILE',
+  })],
 };

--- a/packages/adblocker-electron/test/adblocker.test.ts
+++ b/packages/adblocker-electron/test/adblocker.test.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { ElectronBlocker, ElectronRequestType, fromElectronDetails } from '../adblocker';
+import {
+  ElectronBlocker,
+  ElectronRequestType,
+  fromElectronDetails,
+  getHostnameHashesFromLabelsBackward,
+} from '../adblocker';
 
 describe('#fromElectronDetails', () => {
   const baseRequest: Electron.OnBeforeRequestListenerDetails = {
@@ -16,8 +21,7 @@ describe('#fromElectronDetails', () => {
 
   it('gets sourceUrl from referrer', () => {
     expect(fromElectronDetails(baseRequest)).to.deep.include({
-      sourceDomain: 'source.com',
-      sourceHostname: 'sub.source.com',
+      sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.source.com', 'source.com'),
     });
   });
 

--- a/packages/adblocker-puppeteer/test/adblocker.test.ts
+++ b/packages/adblocker-puppeteer/test/adblocker.test.ts
@@ -3,7 +3,7 @@ import 'mocha';
 
 import * as puppeteer from 'puppeteer';
 
-import { fromPuppeteerDetails } from '../adblocker';
+import { fromPuppeteerDetails, getHostnameHashesFromLabelsBackward } from '../adblocker';
 
 describe('#fromPuppeteerDetails', () => {
   const baseFrame: Partial<puppeteer.Frame> = {
@@ -18,8 +18,7 @@ describe('#fromPuppeteerDetails', () => {
 
   it('gets sourceUrl from frame', () => {
     expect(fromPuppeteerDetails(baseRequest as puppeteer.Request)).to.deep.include({
-      sourceDomain: 'source.com',
-      sourceHostname: 'sub.source.com',
+      sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.source.com', 'source.com'),
     });
   });
 

--- a/packages/adblocker-webextension-cosmetics/rollup.config.ts
+++ b/packages/adblocker-webextension-cosmetics/rollup.config.ts
@@ -18,5 +18,8 @@ export default {
     name: 'adblocker',
     sourcemap: true,
   },
-  plugins: [resolve(), sourcemaps(), compiler()],
+  plugins: [resolve(), sourcemaps(), compiler({
+    // language: 'ECMASCRIPT6_STRICT',
+    language_out: 'NO_TRANSPILE',
+  })],
 };

--- a/packages/adblocker-webextension/rollup.config.ts
+++ b/packages/adblocker-webextension/rollup.config.ts
@@ -18,5 +18,8 @@ export default {
     name: 'adblocker',
     sourcemap: true,
   },
-  plugins: [resolve(), sourcemaps(), compiler()],
+  plugins: [resolve(), sourcemaps(), compiler({
+    // language: 'ECMASCRIPT6_STRICT',
+    language_out: 'NO_TRANSPILE',
+  })],
 };

--- a/packages/adblocker-webextension/test/adblocker.test.ts
+++ b/packages/adblocker-webextension/test/adblocker.test.ts
@@ -1,7 +1,12 @@
 import { expect } from 'chai';
 import 'mocha';
 
-import { fromWebRequestDetails, updateResponseHeadersWithCSP, OnBeforeRequestDetailsType } from '../adblocker';
+import {
+  fromWebRequestDetails,
+  updateResponseHeadersWithCSP,
+  OnBeforeRequestDetailsType,
+  getHostnameHashesFromLabelsBackward,
+} from '../adblocker';
 
 describe('#updateResponseHeadersWithCSP', () => {
   const baseDetails: OnBeforeRequestDetailsType = {
@@ -68,8 +73,7 @@ describe('#fromWebRequestDetails', () => {
         url: 'https://url',
       }),
     ).to.deep.include({
-      sourceDomain: 'foo.com',
-      sourceHostname: 'sub.foo.com',
+      sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.foo.com', 'foo.com'),
     });
   });
 
@@ -83,8 +87,7 @@ describe('#fromWebRequestDetails', () => {
         url: 'https://url',
       }),
     ).to.deep.include({
-      sourceDomain: 'foo.com',
-      sourceHostname: 'sub.foo.com',
+      sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.foo.com', 'foo.com'),
     });
   });
 
@@ -98,8 +101,7 @@ describe('#fromWebRequestDetails', () => {
         url: 'https://url',
       }),
     ).to.deep.include({
-      sourceDomain: 'foo.com',
-      sourceHostname: 'sub.foo.com',
+      sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.foo.com', 'foo.com'),
     });
   });
 
@@ -117,8 +119,7 @@ describe('#fromWebRequestDetails', () => {
       hostname: 'sub.url.com',
       url: 'https://sub.url.com',
 
-      sourceDomain: 'source.com',
-      sourceHostname: 'sub.source.com',
+      sourceHostnameHashes: getHostnameHashesFromLabelsBackward('sub.source.com', 'source.com'),
 
       type: 'script',
     });

--- a/packages/adblocker/adblocker.ts
+++ b/packages/adblocker/adblocker.ts
@@ -15,6 +15,7 @@ export {
   WebRequestType,
   ElectronRequestType,
   PuppeteerRequestType,
+  getHostnameHashesFromLabelsBackward,
 } from './src/request';
 export { default as CosmeticFilter } from './src/filters/cosmetic';
 export { default as NetworkFilter } from './src/filters/network';

--- a/packages/adblocker/package.json
+++ b/packages/adblocker/package.json
@@ -29,6 +29,7 @@
     "bundle": "tsc --build ./tsconfig.bundle.json && rollup --config ./rollup.config.ts",
     "prepack": "yarn run bundle",
     "test": "nyc mocha --config ../../.mocharc.js",
+    "dev": "mocha --config ../../.mocharc.js --watch",
     "bump-internal-engine-version": "ts-node --project ./tools/tsconfig.json ./tools/auto-bump-engine-version.ts",
     "generate-codebooks": "concurrently -n build: yarn:codebook-* && yarn bump-internal-engine-version",
     "codebook-network-csp": "ts-node --project ./tools/tsconfig.json ./tools/generate_compression_codebooks.ts -- network-csp",

--- a/packages/adblocker/rollup.config.ts
+++ b/packages/adblocker/rollup.config.ts
@@ -18,5 +18,8 @@ export default {
     name: 'adblocker',
     sourcemap: true,
   },
-  plugins: [resolve(), sourcemaps(), compiler()],
+  plugins: [resolve(), sourcemaps(), compiler({
+    // language: 'ECMASCRIPT6_STRICT',
+    language_out: 'NO_TRANSPILE',
+  })],
 };

--- a/packages/adblocker/src/engine/bucket/cosmetic.ts
+++ b/packages/adblocker/src/engine/bucket/cosmetic.ts
@@ -11,9 +11,11 @@ import Config from '../../config';
 import { StaticDataView } from '../../data-view';
 import CosmeticFilter, {
   DEFAULT_HIDDING_STYLE,
+} from '../../filters/cosmetic';
+import {
   getEntityHashesFromLabelsBackward,
   getHostnameHashesFromLabelsBackward,
-} from '../../filters/cosmetic';
+} from '../../request';
 import { hashStrings, tokenizeNoSkip } from '../../utils';
 import { noopOptimizeCosmetic } from '../optimizer';
 import ReverseIndex from '../reverse-index';

--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -27,7 +27,7 @@ import Resources from '../resources';
 import CosmeticFilterBucket from './bucket/cosmetic';
 import NetworkFilterBucket from './bucket/network';
 
-export const ENGINE_VERSION = 96;
+export const ENGINE_VERSION = 97;
 
 function shouldApplyHideException(filters: NetworkFilter[]): boolean {
   if (filters.length === 0) {

--- a/packages/adblocker/src/utils.ts
+++ b/packages/adblocker/src/utils.ts
@@ -9,6 +9,8 @@
 import { compactTokens } from './compact-set';
 import { TokensBuffer, TOKENS_BUFFER } from './tokens-buffer';
 
+export const HASH_SEED = 7877;
+
 /***************************************************************************
  *  Bitwise helpers
  * ************************************************************************* */
@@ -33,7 +35,7 @@ export function clearBit(n: number, mask: number): number {
 }
 
 export function fastHashBetween(str: string, begin: number, end: number): number {
-  let hash = 5381;
+  let hash = HASH_SEED;
 
   for (let i = begin; i < end; i += 1) {
     hash = (hash * 33) ^ str.charCodeAt(i);
@@ -151,13 +153,13 @@ export function tokenizeWithWildcardsInPlace(
   let inside = false;
   let precedingCh = 0;
   let start = 0;
-  let hash = 5381;
+  let hash = HASH_SEED;
 
   for (let i = 0; i < len; i += 1) {
     const ch = pattern.charCodeAt(i);
     if (isAllowedCode(ch) === true) {
       if (inside === false) {
-        hash = 5381;
+        hash = HASH_SEED;
         inside = true;
         start = i;
       }
@@ -200,13 +202,13 @@ export function tokenizeInPlace(
   const len = Math.min(pattern.length, buffer.remaining() * 2);
   let inside = false;
   let start = 0;
-  let hash = 5381;
+  let hash = HASH_SEED;
 
   for (let i = 0; i < len; i += 1) {
     const ch = pattern.charCodeAt(i);
     if (isAllowedCode(ch) === true) {
       if (inside === false) {
-        hash = 5381;
+        hash = HASH_SEED;
         inside = true;
         start = i;
       }
@@ -236,13 +238,13 @@ export function tokenizeNoSkipInPlace(pattern: string, buffer: TokensBuffer): vo
   const len = Math.min(pattern.length, buffer.remaining() * 2);
   let inside = false;
   let start = 0;
-  let hash = 5381;
+  let hash = HASH_SEED;
 
   for (let i = 0; i < len; i += 1) {
     const ch = pattern.charCodeAt(i);
     if (isAllowedCode(ch) === true) {
       if (inside === false) {
-        hash = 5381;
+        hash = HASH_SEED;
         inside = true;
         start = i;
       }

--- a/packages/adblocker/test/matching.test.ts
+++ b/packages/adblocker/test/matching.test.ts
@@ -11,20 +11,25 @@ import 'mocha';
 
 import { getDomain } from 'tldts-experimental';
 
-import CosmeticFilter, {
-  getHashesFromLabelsBackward,
-  getHostnameWithoutPublicSuffix,
-  hashHostnameBackward,
-} from '../src/filters/cosmetic';
+import CosmeticFilter from '../src/filters/cosmetic';
 import NetworkFilter, { isAnchoredByHostname } from '../src/filters/network';
 
 import { f } from '../src/lists';
-import Request, { RequestInitialization, RequestType } from '../src/request';
+import Request, {
+  RequestInitialization,
+  RequestType,
+  getHashesFromLabelsBackward,
+  getHostnameWithoutPublicSuffix,
+  hashHostnameBackward,
+} from '../src/request';
 
 import requests from './data/requests';
 
 use((chai, utils) => {
-  utils.addMethod(chai.Assertion.prototype, 'matchRequest', function (this: any, req: Partial<Request>) {
+  utils.addMethod(chai.Assertion.prototype, 'matchRequest', function (
+    this: any,
+    req: Partial<Request>,
+  ) {
     const filter = this._obj;
     const request = Request.fromRawDetails(req);
 
@@ -37,7 +42,10 @@ use((chai, utils) => {
     );
   });
 
-  utils.addMethod(chai.Assertion.prototype, 'matchHostname', function (this: any, hostname: string) {
+  utils.addMethod(chai.Assertion.prototype, 'matchHostname', function (
+    this: any,
+    hostname: string,
+  ) {
     const filter = this._obj;
     new chai.Assertion(filter).not.to.be.null;
 
@@ -52,8 +60,8 @@ use((chai, utils) => {
 declare global {
   namespace Chai {
     interface Assertion {
-        matchRequest(req: Partial<RequestInitialization>): Assertion;
-        matchHostname(hostname: string): Assertion;
+      matchRequest(req: Partial<RequestInitialization>): Assertion;
+      matchHostname(hostname: string): Assertion;
     }
   }
 }
@@ -347,6 +355,10 @@ describe('#NetworkFilter.match', () => {
       sourceUrl: 'http://foo.com',
       url: 'https://foo.com/bar',
     });
+    expect(f`||foo$domain=sub1.foo.com`).not.to.matchRequest({
+      sourceUrl: 'http://sub2.sub1.bar.com',
+      url: 'https://foo.com/bar',
+    });
     expect(f`||foo$domain=foo.com`).not.to.matchRequest({
       sourceUrl: 'http://bar.com',
       url: 'https://foo.com/bar',
@@ -359,6 +371,14 @@ describe('#NetworkFilter.match', () => {
     });
     expect(f`||foo$domain=~bar.com`).not.to.matchRequest({
       sourceUrl: 'http://bar.com',
+      url: 'https://foo.com/bar',
+    });
+    expect(f`||foo$domain=~bar.com`).not.to.matchRequest({
+      sourceUrl: 'http://sub.bar.com',
+      url: 'https://foo.com/bar',
+    });
+    expect(f`||foo$domain=~sub1.bar.com`).not.to.matchRequest({
+      sourceUrl: 'http://sub2.sub1.bar.com',
       url: 'https://foo.com/bar',
     });
   });
@@ -496,25 +516,25 @@ describe('#getHostnameWithoutPublicSuffix', () => {
 describe('#getHashesFromLabelsBackward', () => {
   it('hash all labels', () => {
     expect(getHashesFromLabelsBackward('foo.bar.baz', 11, 11)).to.eql(
-      ['baz', 'bar.baz', 'foo.bar.baz'].map(hashHostnameBackward),
+      new Uint32Array(['baz', 'bar.baz', 'foo.bar.baz'].map(hashHostnameBackward)),
     );
   });
 
   it('hash subdomains only', () => {
     expect(getHashesFromLabelsBackward('foo.bar.baz.com', 15, 8 /* start of domain */)).to.eql(
-      ['baz.com', 'bar.baz.com', 'foo.bar.baz.com'].map(hashHostnameBackward),
+      new Uint32Array(['baz.com', 'bar.baz.com', 'foo.bar.baz.com'].map(hashHostnameBackward)),
     );
   });
 
   it('hash ignoring suffix', () => {
     expect(getHashesFromLabelsBackward('foo.bar.baz.com', 11, 11)).to.eql(
-      ['baz', 'bar.baz', 'foo.bar.baz'].map(hashHostnameBackward),
+      new Uint32Array(['baz', 'bar.baz', 'foo.bar.baz'].map(hashHostnameBackward)),
     );
   });
 
   it('hash subdomains only, ignoring suffix', () => {
     expect(getHashesFromLabelsBackward('foo.bar.baz.com', 11, 8)).to.eql(
-      ['baz', 'bar.baz', 'foo.bar.baz'].map(hashHostnameBackward),
+      new Uint32Array(['baz', 'bar.baz', 'foo.bar.baz'].map(hashHostnameBackward)),
     );
   });
 });

--- a/packages/adblocker/tools/stress-test-engine-update.ts
+++ b/packages/adblocker/tools/stress-test-engine-update.ts
@@ -1,0 +1,424 @@
+/*!
+ * Copyright (c) 2017-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * This script can be used to stress-test the adblocker and validate our filter
+ * builder at the same time. In a nutshell, it will download all the supported
+ * lists (available on CDN), as well as all the possible diffs from one version
+ * to the next for each list then perform the following:
+ *
+ * 1. check: FiltersEngine can be initialized from list
+ * 2. check: FiltersEngine can be updated with diff
+ * 3. check: serialized version of FiltersEngine is byte-identical after update
+ * 4. check: serialized versions can be de-serialized into the same FiltersEngine
+ * 5. check: no ID collisions for filters
+ */
+
+import axios from 'axios';
+import { brotliDecompressSync } from 'zlib';
+import {
+  Config,
+  FiltersEngine,
+  generateDiff,
+  getLinesWithFilters,
+  parseFilter,
+} from '../adblocker';
+import { typedArrayEqual } from '../test/utils';
+
+/**
+ * Convert `option` into its normalized version, if any. Otherwise return the
+ * option un-changed. For example `stylesheet` will be normalized to `css`.
+ * This particular helper could eventually be included in the adblocker library
+ * directly but it is not yet clear if the expected performance overhead is
+ * worth it.
+ *
+ * This transformation is needed so that we can actually detect diffs. In some
+ * cases, filters are simply migrated to new option: 'foo$stylesheet' to
+ * 'foo$css'. This is conceptually the exact same filter but the original
+ * string is different so the FiltersEngine before and after update would
+ * contain the same filters except in `debug` mode where the rawLine of this
+ * particular filter would not match.
+ */
+function replacer(option: string): string {
+  switch (option) {
+    case 'third-party':
+      return '3p';
+    case 'first-party':
+      return '1p';
+    case 'object-subrequest':
+      return 'object';
+    case 'stylesheet':
+      return 'css';
+    case 'subdocument':
+      return 'frame';
+    case 'xmlhttprequest':
+      return 'xhr';
+    case 'document':
+      return 'doc';
+    default:
+      return 'option';
+  }
+}
+
+/**
+ * Normalize a raw filter by replacing options with their canonical forms. For
+ * example `||foo.com$stylesheet,first-party,xhr` would be normalized to
+ * `||foo.com$css,1p,xhr`.
+ */
+const REGEX = /third-party|first-party|object-subrequest|stylesheet|subdocument|xmlhttprequest|document/g;
+function normalizeFilters(rawFilter: string): string {
+  if (rawFilter.startsWith('|http*://$')) {
+    rawFilter = rawFilter.slice(9);
+  }
+
+  if (rawFilter.includes('object,object')) {
+    rawFilter = rawFilter.replace('object,object', 'object');
+  }
+
+  const indexOfOptions = rawFilter.lastIndexOf('$');
+  if (indexOfOptions === -1) {
+    return rawFilter;
+  }
+
+  REGEX.lastIndex = indexOfOptions;
+  return rawFilter.replace(REGEX, replacer);
+}
+
+/**
+ * Global config used for all `FiltersEngine`. This allows to change options
+ * globally without having to change all used configs.
+ */
+const ENGINE_CONFIG = new Config({
+  debug: true,
+});
+
+/**
+ * Make sure instances of CosmeticFilter and NetworkFilter from strings in
+ * `filters` do not yield any IDs collision. In otherwise, check that there are
+ * not any two filters from `filters` with the same ID.
+ */
+function checkIdCollisions(filters: Set<string>): string[] {
+  const collisions: string[] = [];
+
+  const ids: Map<number, string> = new Map();
+  for (const line of Array.from(filters)) {
+    const filter = parseFilter(line);
+    if (filter !== null) {
+      const id = filter.getId();
+      if (ids.has(id)) {
+        collisions.push(`${line} collides with ${ids.get(id)}`);
+      } else {
+        ids.set(id, line);
+      }
+    }
+  }
+
+  return collisions;
+}
+
+/**
+ * Given two sets of filters (in raw string form), return a list of differences
+ * between them (i.e.: filters in one set but not the other).
+ */
+function filtersDiff(
+  name1: string,
+  filters1: Set<string>,
+  name2: string,
+  filters2: Set<string>,
+): string[] {
+  const differences: string[] = [];
+  for (const f of Array.from(filters1)) {
+    if (!filters2.has(f)) {
+      differences.push(`Filter in ${name1} but not ${name2}: ${f}`);
+    }
+  }
+
+  for (const f of Array.from(filters2)) {
+    if (!filters1.has(f)) {
+      differences.push(`Filter in ${name2} but not ${name1}: ${f}`);
+    }
+  }
+
+  return differences;
+}
+
+async function getMeta(url: string): Promise<any> {
+  const meta = (await axios.get(url)).data;
+  if (typeof meta === 'string') {
+    const buffer = Buffer.from(
+      (await axios.get(url, {
+        responseType: 'arraybuffer',
+      })).data,
+    );
+    return JSON.parse(brotliDecompressSync(buffer).toString('utf-8'));
+  }
+
+  return meta;
+}
+
+/**
+ * Return the CDN URL of a specific revision `rev` (a hash) of subscription `list` (e.g. 'easylist').
+ */
+function urlOfRevision(list: string, rev: string): string {
+  return `https://cdn.cliqz.com/adblocker/resources/${list}/${rev}/list.txt`;
+}
+
+/**
+ * Fetch a list from CDN (given its URL). Apart from performing the fetching,
+ * we also take care of detecting if the list was compressed using brotli
+ * (which was the case before; then we switched to gzip for broader
+ * compatibility).
+ */
+const REVISIONS_CACHE: Map<string, string> = new Map();
+async function getRevision(url: string): Promise<string> {
+  const cached = REVISIONS_CACHE.get(url);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let data = (await axios.get(url)).data;
+  if (!data.startsWith('[Ad')) {
+    const buffer = Buffer.from(
+      (await axios.get(url, {
+        responseType: 'arraybuffer',
+      })).data,
+    );
+
+    try {
+      data = brotliDecompressSync(buffer).toString('utf-8');
+    } catch (ex) {
+      // Data is probably already decompressed
+    }
+  }
+
+  REVISIONS_CACHE.set(url, data);
+
+  return data;
+}
+
+/**
+ * Return a set of filters (in their raw string form) from raw list. Also takes
+ * care of normalizing options (e.g.: `stylesheet` -> `css`).
+ */
+function getFiltersFromList(list: string): Set<string> {
+  return new Set(Array.from(getLinesWithFilters(list, ENGINE_CONFIG)).map(normalizeFilters));
+}
+
+/**
+ * Return set of filters (in their raw string form) from a `FiltersEngine` instance.
+ */
+function getFiltersFromEngine(engine: FiltersEngine): Set<string> {
+  const { networkFilters, cosmeticFilters } = engine.getFilters();
+
+  return new Set([
+    ...networkFilters.map(({ rawLine }) => normalizeFilters(rawLine as string)),
+    ...cosmeticFilters.map(({ rawLine }) => normalizeFilters(rawLine as string)),
+  ]);
+}
+
+/**
+ * Return a serialized version of the `FiltersEngine` instance initialized from
+ * `list`. Takes care of caching engines initialized from the same list and
+ * return a copy of the serialized version to make sure no mutation is
+ * possible.
+ */
+const ENGINES_CACHE: Map<string, Uint8Array> = new Map();
+function getEngineFromList(list: string): Uint8Array {
+  const cached = ENGINES_CACHE.get(list);
+  if (cached !== undefined) {
+    return cached.slice();
+  }
+
+  // Create FiltersEngine instance
+  const engine = new FiltersEngine({ config: ENGINE_CONFIG });
+  engine.updateFromDiff({
+    added: Array.from(getFiltersFromList(list)),
+  });
+  const serialized = engine.serialize();
+
+  // Cache for next time
+  ENGINES_CACHE.set(list, serialized);
+
+  return serialized.slice();
+}
+
+interface TestCase {
+  currentList: string;
+  currentRevision: string;
+  previousList: string;
+  previousRevision: string;
+}
+
+/**
+ * Fetch all versions of subscription `list` as well as all the available
+ * updates (i.e.: diffs) from CDN. These will then be used to make sure all
+ * updates are valid and that FiltersEngine can always be updated from them.
+ */
+async function collectTestCases(list: string): Promise<TestCase[]> {
+  const cases: {
+    currentRevision: string;
+    previousRevision: string;
+  }[] = [];
+  const meta = await getMeta(`https://cdn.cliqz.com/adblocker/resources/${list}/metadata.json`);
+  const revisions: Set<string> = new Set();
+
+  // Append current revision (the most recent one)
+  const previousRevisions = [...meta.revisions];
+  console.log('revisions', previousRevisions);
+
+  // Skip the first one which will not have any previous rev
+  for (let i = 1; i < previousRevisions.length; i += 1) {
+    const currentRevision = previousRevisions[i];
+    revisions.add(currentRevision);
+    for (let j = Math.max(i - 7, 0); j < i; j += 1) {
+      const previousRevision = previousRevisions[j];
+      revisions.add(previousRevision);
+      cases.push({
+        currentRevision,
+        previousRevision,
+      });
+    }
+  }
+
+  // Fetch revisions
+  console.log('fetch...');
+  for (const revision of revisions) {
+    console.log(' ~', revision);
+    await getRevision(urlOfRevision(list, revision));
+  }
+
+  console.log('done fetching!');
+  const testCases: TestCase[] = [];
+  for (const { previousRevision, currentRevision } of cases) {
+    const previousList = REVISIONS_CACHE.get(urlOfRevision(list, previousRevision));
+    const currentList = REVISIONS_CACHE.get(urlOfRevision(list, currentRevision));
+
+    if (previousList !== undefined && currentList !== undefined) {
+      testCases.push({
+        currentList,
+        currentRevision,
+        previousList,
+        previousRevision,
+      });
+    }
+  }
+
+  return testCases;
+}
+
+/**
+ * Start stress-test!
+ */
+async function run() {
+  for (const list of [
+    'cliqz-filters',
+    'easylist',
+    'easyprivacy',
+    'plowe-0',
+    'ublock-abuse',
+    'ublock-badware',
+    'ublock-filters',
+    'ublock-privacy',
+    'ublock-unbreak',
+    'whotracksme-filters',
+  ]) {
+    console.log(`> ${list}`);
+    const testCases = await collectTestCases(list);
+    console.log('?', testCases);
+    REVISIONS_CACHE.clear(); // free memory
+
+    for (const { previousRevision, currentRevision, currentList, previousList } of testCases) {
+      console.log(` + ${previousRevision} => ${currentRevision}`);
+
+      // Generate diff between two versions
+      let diff = generateDiff(previousList, currentList, ENGINE_CONFIG);
+      diff = {
+        added: diff.added.map(normalizeFilters),
+        removed: diff.removed.map(normalizeFilters),
+      };
+
+      // No update?
+      if (diff.added.length === 0 && diff.removed.length === 0) {
+        console.log('Diff is empty, skipping...');
+        continue;
+      }
+
+      // Check that previous rev and current rev do not yield the same Engine
+      const currentEngineSerialized = getEngineFromList(currentList);
+      const previousEngineSerialized = getEngineFromList(previousList);
+      const previousEngine = FiltersEngine.deserialize(previousEngineSerialized);
+
+      if (typedArrayEqual(currentEngineSerialized, previousEngineSerialized)) {
+        console.log(JSON.stringify(diff, null, 2));
+        throw new Error('Expected engines to not be equal');
+      }
+
+      // Update `previousEngine` with diff and expect to find `currentEngine`
+      const updated = previousEngine.updateFromDiff(diff);
+      if (updated === false) {
+        console.log(JSON.stringify(diff, null, 2));
+        throw new Error('Expected engine to have been updated');
+      }
+
+      // Check filters are the same
+      const filtersFromList = getFiltersFromList(currentList);
+
+      const collisions = checkIdCollisions(filtersFromList);
+      if (collisions.length !== 0) {
+        console.log('Found ID collisions');
+        for (const collision of collisions) {
+          console.log(collision);
+        }
+      }
+
+      const filtersFromCurrentEngine = getFiltersFromEngine(
+        FiltersEngine.deserialize(currentEngineSerialized),
+      );
+      const filtersFromUpdatedEngine = getFiltersFromEngine(previousEngine);
+
+      const diff1 = filtersDiff('fromList', filtersFromList, 'fromFull', filtersFromCurrentEngine);
+      if (diff1.length !== 0) {
+        console.log('Found discrepancy in filters');
+        for (const difference of diff1) {
+          console.log(difference);
+        }
+        continue; // TODO - ignore other checks?
+      }
+
+      const diff2 = filtersDiff(
+        'fromList',
+        filtersFromList,
+        'fromUpdated',
+        filtersFromUpdatedEngine,
+      );
+
+      if (diff2.length !== 0) {
+        console.log('Found discrepancy in filters');
+        for (const difference of diff2) {
+          console.log(difference);
+        }
+        continue; // TODO - ignore other checks?
+      }
+
+      const updatedEngineSerialized = previousEngine.serialize();
+      if (typedArrayEqual(updatedEngineSerialized, currentEngineSerialized) === false) {
+        throw new Error('Expected serialized engines to be equal');
+      }
+
+      // Make sure we can re-serialize on top of updated engine
+      const reSerialized = FiltersEngine.deserialize(updatedEngineSerialized).serialize();
+      if (typedArrayEqual(reSerialized, currentEngineSerialized) === false) {
+        throw new Error('Expected re-serialized engines to be equal');
+      }
+    }
+
+    ENGINES_CACHE.clear();
+  }
+}
+
+run();

--- a/packages/adblocker/tools/tsconfig.json
+++ b/packages/adblocker/tools/tsconfig.json
@@ -6,6 +6,10 @@
     "composite": true
   },
   "files": [
-    "generate_compression_codebooks.ts"
+    "auto-bump-engine-version.ts",
+    "engine-size.ts",
+    "generate_compression_codebooks.ts",
+    "priorities.ts",
+    "stress-test-engine-update.ts"
   ]
 }


### PR DESCRIPTION
## Release Notes

* Make sure that all unsupported procedural selectors from cosmetic filters are dropped to ensure that we only inject valid CSS selectors.
* Fix matching of `domain=` option for domain filters in cases where specified domain is a subdomain instead of full hostname or full domain.
* Fix partyness detection for requests without a valid domain (but having a valid hostname). This fixes matching against localhost request (for instance).
* Fix engine updates stress test which allows to replay all day-to-day diffs since the beginning of times... (currently about a year) and make sure that all updates work and resulting engine is byte-identical with diff-update or full initialization.
* Fix script to analyze size of serialized engines for all presets as well as all kinds of compression (i.e. none, gzip and brotli). This allows to keep track of final size after small-strings compression was applied.