### PR TITLE
Extension engine size script

### DIFF
--- a/packages/adblocker/tools/engine-size.ts
+++ b/packages/adblocker/tools/engine-size.ts
@@ -43,15 +43,21 @@ function loadFullLists(): Promise<string> {
     ['ads + trackers', await loadAdsAndTrackingLists()],
     ['ads + trackers + annoyances', await loadFullLists()],
   ]) {
-    const engine = FiltersEngine.parse(raw, { enableCompression: true });
-    const { networkFilters, cosmeticFilters } = engine.getFilters();
-    console.log(`> ${name} (${networkFilters.length} network + ${cosmeticFilters.length} hide)`);
-    for (const [compression, compress] of [
-      ['raw', (b: Uint8Array) => b],
-      ['gzip', gzipSync],
-      ['brotlit', brotliCompressSync],
-    ] as [string, (b: Uint8Array) => Uint8Array][]) {
-      console.log(' +', compression, compress(engine.serialize()).byteLength, 'bytes');
+    for (const config of [
+      { loadNetworkFilters: true, loadCosmeticFilters: true },
+      { loadNetworkFilters: false, loadCosmeticFilters: true },
+      { loadNetworkFilters: true, loadCosmeticFilters: false },
+    ]) {
+      const engine = FiltersEngine.parse(raw, { enableCompression: true, ...config });
+      const { networkFilters, cosmeticFilters } = engine.getFilters();
+      console.log(`> ${name} (${networkFilters.length} network + ${cosmeticFilters.length} hide)`);
+      for (const [compression, compress] of [
+        ['raw', (b: Uint8Array) => b],
+        ['gzip', gzipSync],
+        ['brotli', brotliCompressSync],
+      ] as [string, (b: Uint8Array) => Uint8Array][]) {
+        console.log(' +', compression, compress(engine.serialize()).byteLength, 'bytes');
+      }
     }
   }
 })();


### PR DESCRIPTION
* ads (47150 network + 48581 hide)
    + raw 3404432 bytes
    + gzip 1733034 bytes
    + brotli 1498846 bytes
* ads (0 network + 48581 hide)
    + raw 1847381 bytes
    + gzip 927739 bytes
    + brotli 800441 bytes
* ads (47150 network + 0 hide)
    + raw 1557292 bytes
    + gzip 805273 bytes
    + brotli 705317 bytes
* ads + trackers (64393 network + 48594 hide)
    + raw 3827004 bytes
    + gzip 1987752 bytes
    + brotli 1720033 bytes
* ads + trackers (0 network + 48594 hide)
    + raw 1848961 bytes
    + gzip 928312 bytes
    + brotli 799646 bytes
* ads + trackers (64393 network + 0 hide)
    + raw 1978284 bytes
    + gzip 1060566 bytes
    + brotli 924898 bytes
* ads + trackers + annoyances (65537 network + 62029 hide)
    + raw 4224348 bytes
    + gzip 2219523 bytes
    + brotli 1921846 bytes
* ads + trackers + annoyances (0 network + 62029 hide)
    + raw 2219065 bytes
    + gzip 1144129 bytes
    + brotli 989398 bytes
* ads + trackers + annoyances (65537 network + 0 hide)
    + raw 2005524 bytes
    + gzip 1074618 bytes
    + brotli 937992 bytes