### PR TITLE
feat: support denyallow option and entities for network filters

### DIFF
--- a/packages/adblocker/src/engine/domains.ts
+++ b/packages/adblocker/src/engine/domains.ts
@@ -1,0 +1,231 @@
+/*!
+ * Copyright (c) 2017-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { hashHostnameBackward } from '../request';
+import { toASCII } from '../punycode';
+import { StaticDataView, sizeOfUint32Array } from '../data-view';
+import { binLookup, hasUnicode } from '../utils';
+
+export class Domains {
+  public static parse(parts: string[]): Domains | undefined {
+    if (parts.length === 0) {
+      return undefined;
+    }
+
+    const entities: number[] = [];
+    const notEntities: number[] = [];
+    const hostnames: number[] = [];
+    const notHostnames: number[] = [];
+
+    for (let i = 0; i < parts.length; i += 1) {
+      let hostname = parts[i];
+      if (hasUnicode(hostname)) {
+        hostname = toASCII(hostname);
+      }
+
+      const negation: boolean = hostname.charCodeAt(0) === 126; /* '~' */
+      const entity: boolean =
+        hostname.charCodeAt(hostname.length - 1) === 42 /* '*' */ &&
+        hostname.charCodeAt(hostname.length - 2) === 46; /* '.' */
+
+      const start: number = negation ? 1 : 0;
+      const end: number = entity ? hostname.length - 2 : hostname.length;
+
+      const hash = hashHostnameBackward(
+        negation === true || entity === true ? hostname.slice(start, end) : hostname,
+      );
+
+      if (negation) {
+        if (entity) {
+          notEntities.push(hash);
+        } else {
+          notHostnames.push(hash);
+        }
+      } else {
+        if (entity) {
+          entities.push(hash);
+        } else {
+          hostnames.push(hash);
+        }
+      }
+    }
+
+    return new Domains({
+      entities: (entities.length !== 0 ? new Uint32Array(entities).sort() : undefined),
+      hostnames: (hostnames.length !== 0 ? new Uint32Array(hostnames).sort() : undefined),
+      notEntities: (notEntities.length !== 0 ? new Uint32Array(notEntities).sort() : undefined),
+      notHostnames: (notHostnames.length !== 0 ? new Uint32Array(notHostnames).sort() : undefined),
+    });
+  }
+
+  public static deserialize(buffer: StaticDataView): Domains {
+    const optionalParts = buffer.getUint8();
+
+    // The order of these fields should be the same as when we serialize them.
+    return new Domains({
+      entities: ((optionalParts & 1) === 1 ? buffer.getUint32Array() : undefined),
+      hostnames: ((optionalParts & 2) === 2 ? buffer.getUint32Array() : undefined),
+      notEntities: ((optionalParts & 4) === 4 ? buffer.getUint32Array() : undefined),
+      notHostnames: ((optionalParts & 8) === 8 ? buffer.getUint32Array() : undefined),
+    });
+  }
+
+  // hostnames
+  public readonly entities: Uint32Array | undefined;
+  public readonly hostnames: Uint32Array | undefined;
+
+  // Exceptions
+  public readonly notEntities: Uint32Array | undefined;
+  public readonly notHostnames: Uint32Array | undefined;
+
+  constructor({
+    entities,
+    hostnames,
+    notEntities,
+    notHostnames,
+  }: {
+    entities: Uint32Array | undefined;
+    hostnames: Uint32Array | undefined;
+    notEntities: Uint32Array | undefined;
+    notHostnames: Uint32Array | undefined;
+  }) {
+    // Hostname constraints
+    this.entities = entities;
+    this.hostnames = hostnames;
+
+    // Hostname exceptions
+    this.notEntities = notEntities;
+    this.notHostnames = notHostnames;
+  }
+
+  public updateId(hash: number): number {
+    const { hostnames, entities, notHostnames, notEntities } = this;
+
+    if (hostnames !== undefined) {
+      for (let i = 0; i < hostnames.length; i += 1) {
+        hash = (hash * 33) ^ hostnames[i];
+      }
+    }
+
+    if (entities !== undefined) {
+      for (let i = 0; i < entities.length; i += 1) {
+        hash = (hash * 33) ^ entities[i];
+      }
+    }
+
+    if (notHostnames !== undefined) {
+      for (let i = 0; i < notHostnames.length; i += 1) {
+        hash = (hash * 33) ^ notHostnames[i];
+      }
+    }
+
+    if (notEntities !== undefined) {
+      for (let i = 0; i < notEntities.length; i += 1) {
+        hash = (hash * 33) ^ notEntities[i];
+      }
+    }
+
+    return hash;
+  }
+
+  public serialize(buffer: StaticDataView): void {
+    // Mandatory fields
+    const index = buffer.getPos();
+    buffer.pushUint8(0);
+
+    // This bit-mask indicates which optional parts of the filter were serialized.
+    let optionalParts = 0;
+
+    if (this.entities !== undefined) {
+      optionalParts |= 1;
+      buffer.pushUint32Array(this.entities);
+    }
+
+    if (this.hostnames !== undefined) {
+      optionalParts |= 2;
+      buffer.pushUint32Array(this.hostnames);
+    }
+
+    if (this.notEntities !== undefined) {
+      optionalParts |= 4;
+      buffer.pushUint32Array(this.notEntities);
+    }
+
+    if (this.notHostnames !== undefined) {
+      optionalParts |= 8;
+      buffer.pushUint32Array(this.notHostnames);
+    }
+
+    buffer.setByte(index, optionalParts);
+  }
+
+  public getSerializedSize(): number {
+    let estimate: number = 1; // optional parts (1 byte)
+
+    if (this.entities !== undefined) {
+      estimate += sizeOfUint32Array(this.entities);
+    }
+
+    if (this.hostnames !== undefined) {
+      estimate += sizeOfUint32Array(this.hostnames);
+    }
+
+    if (this.notHostnames !== undefined) {
+      estimate += sizeOfUint32Array(this.notHostnames);
+    }
+
+    if (this.notEntities !== undefined) {
+      estimate += sizeOfUint32Array(this.notEntities);
+    }
+
+    return estimate;
+  }
+
+  public match(hostnameHashes: Uint32Array, entityHashes: Uint32Array): boolean {
+    // Check if `hostname` is blacklisted
+    if (this.notHostnames !== undefined) {
+      for (const hash of hostnameHashes) {
+        if (binLookup(this.notHostnames, hash)) {
+          return false;
+        }
+      }
+    }
+
+    // Check if `hostname` is blacklisted by *entity*
+    if (this.notEntities !== undefined) {
+      for (const hash of entityHashes) {
+        if (binLookup(this.notEntities, hash)) {
+          return false;
+        }
+      }
+    }
+
+    // Check if `hostname` is allowed
+    if (this.hostnames !== undefined || this.entities !== undefined) {
+      if (this.hostnames !== undefined) {
+        for (const hash of hostnameHashes) {
+          if (binLookup(this.hostnames, hash)) {
+            return true;
+          }
+        }
+      }
+
+      if (this.entities !== undefined) {
+        for (const hash of entityHashes) {
+          if (binLookup(this.entities, hash)) {
+            return true;
+          }
+        }
+      }
+
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/adblocker/test/matching.test.ts
+++ b/packages/adblocker/test/matching.test.ts
@@ -369,8 +369,20 @@ describe('#NetworkFilter.match', () => {
       sourceUrl: 'http://foo.com',
       url: 'https://foo.com/bar',
     });
+    expect(f`||foo$domain=~bar.*`).to.matchRequest({
+      sourceUrl: 'http://foo.com',
+      url: 'https://foo.com/bar',
+    });
     expect(f`||foo$domain=~bar.com`).not.to.matchRequest({
       sourceUrl: 'http://bar.com',
+      url: 'https://foo.com/bar',
+    });
+    expect(f`||foo$domain=~bar.*`).not.to.matchRequest({
+      sourceUrl: 'http://bar.com',
+      url: 'https://foo.com/bar',
+    });
+    expect(f`||foo$domain=~bar.*`).not.to.matchRequest({
+      sourceUrl: 'http://bar.co.uk',
       url: 'https://foo.com/bar',
     });
     expect(f`||foo$domain=~bar.com`).not.to.matchRequest({
@@ -380,6 +392,36 @@ describe('#NetworkFilter.match', () => {
     expect(f`||foo$domain=~sub1.bar.com`).not.to.matchRequest({
       sourceUrl: 'http://sub2.sub1.bar.com',
       url: 'https://foo.com/bar',
+    });
+
+    // denyallow
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.matchRequest({
+      sourceUrl: 'https://a.com',
+      url: 'https://z.com/bar',
+    });
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.matchRequest({
+      sourceUrl: 'https://b.com',
+      url: 'https://z.com/bar',
+    });
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.matchRequest({
+      sourceUrl: 'https://sub.b.com',
+      url: 'https://z.com/bar',
+    });
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.not.matchRequest({
+      sourceUrl: 'https://a.com',
+      url: 'https://x.com/bar',
+    });
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.not.matchRequest({
+      sourceUrl: 'https://a.com',
+      url: 'https://sub.y.com/bar',
+    });
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.not.matchRequest({
+      sourceUrl: 'https://sub.b.com',
+      url: 'https://sub.y.com/bar',
+    });
+    expect(f`*$3p,denyallow=x.com|y.com,domain=a.com|b.com`).to.not.matchRequest({
+      sourceUrl: 'https://c.com',
+      url: 'https://sub.y.com/bar',
     });
   });
 });


### PR DESCRIPTION
# What Changed

* Add support for [`denyallow` option](https://github.com/uBlockOrigin/uBlock-issues/wiki/Static-filter-syntax#denyallow) in network filters.
* Add support for [entities](https://github.com/uBlockOrigin/uBlock-issues/wiki/Static-filter-syntax#entity) in both `domain` and `denyallow` options.
* Refactor handling of matching against lists of domains and entities (including negation) into the `Domains` class, used for matching of `domain=`, `denyallow=` options as well as cosmetics filters.

## Release Notes

Add support for two new features to make network filtering more flexible and powerful. The new [`denyallow` option](https://github.com/uBlockOrigin/uBlock-issues/wiki/Static-filter-syntax#denyallow) is now fully supported. Moreover, both the new `denyallow` and existing `domain` options can contain [entities](https://github.com/uBlockOrigin/uBlock-issues/wiki/Static-filter-syntax#entity), allowing the use of trailing wildcards to match against all public suffixes (e.g. `evil.*` will match `evil` followed by any valid public suffix like `evil.com` or `evil.co.uk`).