### PR TITLE
Update puppeteer types to 5.x

### DIFF
--- a/packages/adblocker-puppeteer/package.json
+++ b/packages/adblocker-puppeteer/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "peerDependencies": {
-    "@types/puppeteer": "3.x",
+    "@types/puppeteer": "5.x",
     "puppeteer": "5.x"
   },
   "dependencies": {
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.0",
-    "@types/puppeteer": "3.x",
+    "@types/puppeteer": "5.x",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
     "nyc": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,10 +1606,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
-"@types/puppeteer@3.x":
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-3.0.5.tgz#5ef5d023f45c0dfcc82e97548891b11b6ce868fb"
-  integrity sha512-NkphUMkpbr/us6hp1AqUh/UxX5Tf2UJU94MvaF8OOgIUPBipYodql+yRjcysJKqwnDkchp+cD/8jntI/C9StzA==
+"@types/puppeteer@5.x":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@types/puppeteer/-/puppeteer-5.4.0.tgz#1ef860bd7a9dcf0c4633aac8c0ec21f75b431868"
+  integrity sha512-zTYDLjnHjgzokrwKt7N0rgn7oZPYo1J0m8Ghu+gXqzLCEn8RWbELa2uprE2UFJ0jU/Sk0x9jXXdOH/5QQLFHhQ==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
See https://www.npmjs.com/package/@types/puppeteer - types is at 5.4.0 as of writing. This change brings the types in sync with the puppeteer version.