### PR TITLE
Fix memory leak by using a WeakMap to hold context information in blocker

### DIFF
--- a/packages/adblocker-electron/adblocker.ts
+++ b/packages/adblocker-electron/adblocker.ts
@@ -109,7 +109,7 @@ export class BlockingContext {
  * methods to interface with Electron APIs needed to block ads.
  */
 export class ElectronBlocker extends FiltersEngine {
-  private readonly contexts: WeakMap<Electron.Session, BlockingContext> = new Map();
+  private readonly contexts: WeakMap<Electron.Session, BlockingContext> = new WeakMap();
 
   // ----------------------------------------------------------------------- //
   // Helpers to enable and disable blocking for 'browser'

--- a/packages/adblocker-playwright/adblocker.ts
+++ b/packages/adblocker-playwright/adblocker.ts
@@ -98,7 +98,7 @@ export class BlockingContext {
  * methods to interface with Playwright APIs needed to block ads.
  */
 export class PlaywrightBlocker extends FiltersEngine {
-  private readonly contexts: WeakMap<pw.Page, BlockingContext> = new Map();
+  private readonly contexts: WeakMap<pw.Page, BlockingContext> = new WeakMap();
 
   // ----------------------------------------------------------------------- //
   // Helpers to enable and disable blocking for 'browser'
@@ -314,10 +314,7 @@ export class PlaywrightBlocker extends FiltersEngine {
     }
   }
 
-  private async injectScriptletsIntoFrame(
-    frame: pw.Frame,
-    scripts: string[],
-  ): Promise<void> {
+  private async injectScriptletsIntoFrame(frame: pw.Frame, scripts: string[]): Promise<void> {
     const promises: Promise<any>[] = [];
 
     if (scripts.length !== 0) {

--- a/packages/adblocker-puppeteer/adblocker.ts
+++ b/packages/adblocker-puppeteer/adblocker.ts
@@ -103,7 +103,7 @@ export class BlockingContext {
  * methods to interface with Puppeteer APIs needed to block ads.
  */
 export class PuppeteerBlocker extends FiltersEngine {
-  private readonly contexts: WeakMap<puppeteer.Page, BlockingContext> = new Map();
+  private readonly contexts: WeakMap<puppeteer.Page, BlockingContext> = new WeakMap();
 
   // ----------------------------------------------------------------------- //
   // Helpers to enable and disable blocking for 'browser'

--- a/packages/adblocker-webextension/adblocker.ts
+++ b/packages/adblocker-webextension/adblocker.ts
@@ -212,7 +212,7 @@ export class BlockingContext {
  * methods to interface with WebExtension APIs needed to block ads.
  */
 export class WebExtensionBlocker extends FiltersEngine {
-  private readonly contexts: WeakMap<Browser, BlockingContext> = new Map();
+  private readonly contexts: WeakMap<Browser, BlockingContext> = new WeakMap();
 
   // ----------------------------------------------------------------------- //
   // Helpers to enable and disable blocking for 'browser'


### PR DESCRIPTION
Fixes #1449 

The use of a `Map` instead of a `WeakMap` was probably a mistake as the type of this field clearly indicates that it should be a `WeakMap`.

Thank you @victornpb for investigating this issue and hinting to the fix.