### PR TITLE
Fix to executing promises in adblocker-playwright

### DIFF
--- a/packages/adblocker-playwright/adblocker.ts
+++ b/packages/adblocker-playwright/adblocker.ts
@@ -328,7 +328,7 @@ export class PlaywrightBlocker extends FiltersEngine {
       }
     }
 
-    await promises;
+    await Promise.all(promises);
   }
 
   /**


### PR DESCRIPTION
Implement same solution to adblock-puppeteer to executing promises in playwright.