### PR TITLE
Update adblockpluscore to ebfc7b0

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -4,10 +4,10 @@ all: deps run
 requests.json:
 	curl https://cdn.cliqz.com/adblocking/requests_top500.json.gz | gunzip > requests.json
 
-# VERSION: a15e8020d092f7b9f96834d237b6ca560c6b4335
+# VERSION: ebfc7b0300879ad44dba6a051c3c34b508b5a4f7
 ./blockers/adblockpluscore:
-	git clone --branch=next https://github.com/adblockplus/adblockpluscore.git ./blockers/adblockpluscore
-	cd ./blockers/adblockpluscore && git reset --hard a15e8020d092f7b9f96834d237b6ca560c6b4335
+	git clone https://github.com/adblockplus/adblockpluscore.git ./blockers/adblockpluscore
+	cd ./blockers/adblockpluscore && git reset --hard ebfc7b0300879ad44dba6a051c3c34b508b5a4f7
 
 adblockpluscore: ./blockers/adblockpluscore
 


### PR DESCRIPTION
This PR updates adblockpluscore to version ebfc7b0.

Changes:

* `RegExpFilter` is gone
* `RegExpFilter.typeMap` is now `contentTypes`
* The filter type `whitelist` has been changed to `allowing`
*  Using the new `match()` method of the matcher instead of the now deprecated `matchesAny()`

See https://gitlab.com/eyeo/adblockplus/adblockpluscore/-/issues/78