### PR TITLE
Fix brave.js to use FilterSet

### DIFF
--- a/packages/adblocker-benchmarks/blockers/brave.js
+++ b/packages/adblocker-benchmarks/blockers/brave.js
@@ -6,11 +6,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const { Engine } = require('adblock-rs');
+const { Engine, FilterSet } = require('adblock-rs');
 
 module.exports = class Brave {
   static parse(rawLists) {
-    return new Brave(new Engine(rawLists.split(/[\n\r]+/g)));
+    const filterSet = new FilterSet(false);
+    filterSet.addFilters(rawLists.split(/[\n\r]+/g));
+    return new Brave(new Engine(filterSet, true));
   }
 
   constructor(client) {
@@ -18,7 +20,7 @@ module.exports = class Brave {
   }
 
   serialize() {
-    return this.client.serialize();
+    return this.client.serializeCompressed();
   }
 
   deserialize(serialized) {


### PR DESCRIPTION
Since the APIs in [adblock-rs](https://www.npmjs.com/package/adblock-rs) have changed, the Brave benchmarks no longer work. The `Engine` constructor expects a `FilterSet` object. Also, the `serialize()` method is deprecated in favor of `serializeCompressed()`.

This PR updates `brave.js` to fix these issues.