### PR TITLE
Use lowercase name ubo-snfe

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -8,10 +8,10 @@ requests.json:
 ./blockers/ublock/.git:
 	git submodule update --recursive --depth 1 --init blockers/ublock
 
-./node_modules/uBO-snfe:
+./node_modules/ubo-snfe:
 	make -C ./blockers/ublock install-nodejs clean
 
-ubo-snfe: ./blockers/ublock/.git ./node_modules/uBO-snfe
+ubo-snfe: ./blockers/ublock/.git ./node_modules/ubo-snfe
 
 ./blockers/adblockpluscore/.git:
 	git submodule update --recursive --depth 1 --init blockers/adblockpluscore
@@ -57,5 +57,5 @@ run: deps url tldts cliqz ublock adblockplus brave adblockfast
 
 clean:
 	rm -f requests.json
-	npm uninstall uBO-snfe adblock-rs
+	npm uninstall ubo-snfe adblock-rs
 	git submodule deinit --all


### PR DESCRIPTION
uBlock Origin has changed the name of its Node.js package to use all lower case (https://github.com/gorhill/uBlock/commit/8a33bda65319703b2978bb3698711558fc6e97b4).

This is also good for avoiding confusion on filesystems that are case-insensitive.

npm also [requires all lower case](https://blog.npmjs.org/post/168978377570/new-package-moniker-rules.html).