### PR TITLE
Use minified version of Cliqz

### DIFF
--- a/packages/adblocker-benchmarks/blockers/cliqz-base.js
+++ b/packages/adblocker-benchmarks/blockers/cliqz-base.js
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const { FiltersEngine, Request } = require('@cliqz/adblocker');
+const { FiltersEngine, Request } = require('@cliqz/adblocker/dist/adblocker.umd.min.js');
 
 module.exports = class Cliqz {
   static parse(rawLists, enableCompression) {


### PR DESCRIPTION
Based on the comment here: https://github.com/cliqz-oss/adblocker/pull/2091#issuecomment-890521289

Whether the code is minified in this manner seems to make a huge difference in initialization time.