### PR TITLE
Use ubo-snfe/bundle.min.cjs

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -10,6 +10,7 @@ requests.json:
 
 ./node_modules/ubo-snfe:
 	make -C ./blockers/ublock install-nodejs clean
+	npx rollup ./node_modules/ubo-snfe/main.js --file ./node_modules/ubo-snfe/bundle.min.cjs --format cjs --context global --plugin terser
 
 ubo-snfe: ./blockers/ublock/.git ./node_modules/ubo-snfe
 

--- a/packages/adblocker-benchmarks/blockers/ublock.js
+++ b/packages/adblocker-benchmarks/blockers/ublock.js
@@ -6,7 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const modulePromise = import('ubo-snfe');
+const { FilteringContext, pslInit, restart } = require('ubo-snfe/bundle.min.cjs');
 
 class MockStorage {
   constructor(serialized) {
@@ -29,14 +29,10 @@ class MockStorage {
 
 module.exports = class UBlockOrigin {
   static async initialize() {
-    let { pslInit } = await modulePromise;
-
     pslInit();
   }
 
   static async parse(rawLists) {
-    let { FilteringContext, restart } = await modulePromise;
-
     return new UBlockOrigin(restart([ { name: 'easylist', raw: rawLists } ]),
                             new FilteringContext());
   }

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -63,5 +63,9 @@
       "name": "Anton Lazarev",
       "email": "antonok35@gmail.com"
     }
-  ]
+  ],
+  "devDependencies": {
+    "rollup": "^2.55.1",
+    "rollup-plugin-terser": "^7.0.2"
+  }
 }


### PR DESCRIPTION
ubo-snfe now includes a `bundle.min.cjs` that is generated at install time using [rollup.js](https://rollupjs.org/).

Note that in this patch we regenerate the bundle because we want to remove the bundle generation from the install script (https://github.com/gorhill/uBlock/pull/3794#discussion_r680573407)