### PR TITLE
Use bundle.min.cjs for adblockplus

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -10,14 +10,23 @@ requests.json:
 
 ./node_modules/@gorhill/ubo-core:
 	make -C ./blockers/ublock install-nodejs clean
-	npx rollup ./node_modules/@gorhill/ubo-core/index.js --file ./node_modules/@gorhill/ubo-core/bundle.min.cjs --format cjs --context global --plugin terser
+	npx rollup ./node_modules/@gorhill/ubo-core/index.js \
+		--file ./node_modules/@gorhill/ubo-core/bundle.min.cjs --format cjs \
+		--context global --plugin terser
 
 ubo-core: ./blockers/ublock/.git ./node_modules/@gorhill/ubo-core
+
+./node_modules/adblockpluscore:
+	cp -R ./blockers/adblockpluscore ./node_modules
+	cp ./blockers/adblockpluscore-index.js ./node_modules/adblockpluscore/lib
+	npx rollup ./node_modules/adblockpluscore/lib/adblockpluscore-index.js \
+		--file ./node_modules/adblockpluscore/lib/bundle.min.cjs --format cjs \
+		--plugin commonjs --plugin json --plugin terser --output.exports named
 
 ./blockers/adblockpluscore/.git:
 	git submodule update --recursive --depth 1 --init blockers/adblockpluscore
 
-adblockpluscore: ./blockers/adblockpluscore/.git
+adblockpluscore: ./blockers/adblockpluscore/.git ./node_modules/adblockpluscore
 
 ./node_modules/adblock-rs:
 	npm install --no-save adblock-rs
@@ -58,5 +67,5 @@ run: deps url tldts cliqz ublock adblockplus brave adblockfast
 
 clean:
 	rm -f requests.json
-	npm uninstall ubo-core adblock-rs
+	npm uninstall adblockpluscore ubo-core adblock-rs
 	git submodule deinit --all

--- a/packages/adblocker-benchmarks/blockers/adblockplus.js
+++ b/packages/adblocker-benchmarks/blockers/adblockplus.js
@@ -6,10 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const { contentTypes } = require('./adblockpluscore/lib/contentTypes.js');
-const { CombinedMatcher } = require('./adblockpluscore/lib/matcher.js');
-const { Filter } = require('./adblockpluscore/lib/filterClasses.js');
-const { parseURL } = require('./adblockpluscore/lib/url.js');
+const { contentTypes, CombinedMatcher, Filter, parseURL } = require('adblockpluscore/lib/bundle.min.cjs');
 
 // Chrome can't distinguish between OBJECT_SUBREQUEST and OBJECT requests.
 contentTypes.OBJECT_SUBREQUEST = contentTypes.OBJECT;

--- a/packages/adblocker-benchmarks/blockers/adblockpluscore-index.js
+++ b/packages/adblocker-benchmarks/blockers/adblockpluscore-index.js
@@ -1,0 +1,9 @@
+const { contentTypes } = require('./contentTypes.js');
+const { CombinedMatcher } = require('./matcher.js');
+const { Filter } = require('./filterClasses.js');
+const { parseURL } = require('./url.js');
+
+exports.contentTypes = contentTypes;
+exports.CombinedMatcher = CombinedMatcher;
+exports.Filter = Filter;
+exports.parseURL = parseURL;

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -65,6 +65,8 @@
     }
   ],
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-json": "^4.1.0",
     "rollup": "^2.55.1",
     "rollup-plugin-terser": "^7.0.2"
   }


### PR DESCRIPTION
This patch prepares the adblockpluscore package with a `bundle.min.cjs` file similar to the one for uBlock Origin.