### PR TITLE
Integrate @adguard/tsurlfilter

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -5,7 +5,7 @@ ifeq ($(SHOW_MEMORY), 1)
 	run_options := $(run_options) --memory
 endif
 
-.PHONY: all clean deps run ubo-core adblockpluscore adblock-rs brave cliqz cliqz-compression ublock adblockplus tldts url min
+.PHONY: all clean deps run ubo-core adblockpluscore tsurlfilter-node adblock-rs brave cliqz cliqz-compression ublock adblockplus tsurlfilter tldts url min
 
 all: deps run
 
@@ -36,6 +36,14 @@ ubo-core: ./blockers/ublock/.git ./node_modules/@gorhill/ubo-core
 
 adblockpluscore: ./blockers/adblockpluscore/.git ./node_modules/adblockpluscore
 
+./node_modules/@adguard/tsurlfilter:
+	npm install --no-save @adguard/tsurlfilter
+	npx rollup ./node_modules/@adguard/tsurlfilter/dist/tsurlfilter.umd.js \
+		--file ./node_modules/@adguard/tsurlfilter/dist/bundle.min.cjs --format cjs \
+		--context global --plugin terser
+
+tsurlfilter-node: ./node_modules/@adguard/tsurlfilter
+
 ./node_modules/adblock-rs:
 	npm install --no-save adblock-rs
 
@@ -56,6 +64,9 @@ ublock:
 adblockplus:
 	$(node_command) run.js adblockplus $(run_options)
 
+tsurlfilter:
+	$(node_command) run.js tsurlfilter $(run_options)
+
 tldts:
 	$(node_command) run.js tldts $(run_options)
 
@@ -75,5 +86,5 @@ run: deps url tldts cliqz ublock adblockplus brave adblockfast
 
 clean:
 	rm -f requests.json
-	npm uninstall adblockpluscore ubo-core adblock-rs
+	npm uninstall tsurlfilter adblockpluscore ubo-core adblock-rs
 	git submodule deinit --all

--- a/packages/adblocker-benchmarks/blockers/tsurlfilter.js
+++ b/packages/adblocker-benchmarks/blockers/tsurlfilter.js
@@ -1,0 +1,56 @@
+/*!
+ * Copyright (c) 2017-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const {
+  Engine,
+  Request,
+  RequestType,
+  RuleStorage,
+  StringRuleList,
+  setConfiguration,
+} = require('@adguard/tsurlfilter/dist/bundle.min.cjs');
+
+const requestTypes = new Map([
+  [ 'sub_frame', RequestType.Subdocument ],
+  [ 'script', RequestType.Script ],
+  [ 'stylesheet', RequestType.Stylesheet ],
+  [ 'image', RequestType.Image ],
+  [ 'xmlhttprequest', RequestType.XmlHttpRequest ],
+  [ 'media', RequestType.Media ],
+  [ 'font', RequestType.Font ],
+  [ 'other', RequestType.Other ],
+]);
+
+module.exports = class TSUrlFilter {
+  static async initialize() {
+    setConfiguration({
+      engine: 'extension',
+      version: '1.0.0',
+      verbose: true,
+    });
+  }
+
+  static async parse(rawLists) {
+    // The first argument is the list ID and must be unique
+    const list = new StringRuleList(1, rawLists);
+    const ruleStorage = new RuleStorage([ list ]);
+    return new TSUrlFilter(new Engine(ruleStorage));
+  }
+
+  constructor(engine) {
+    this.engine = engine;
+  }
+
+  match({ url, frameUrl, type }) {
+    const requestType = requestTypes.get(type) || RequestType.Other;
+    const request = new Request(url, frameUrl, requestType);
+    const result = this.engine.matchRequest(request);
+    const basicResult = result.getBasicResult();
+    return basicResult !== null && !basicResult.whitelist;
+  }
+};

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -17,13 +17,15 @@
     "download-requests": "make requests.json",
     "download-ubo": "make ubo-core",
     "download-abp": "make adblockpluscore",
+    "download-tsurlfilter": "make tsurlfilter-node",
     "download-brave": "make adblock-rs",
-    "prepare": "yarn download-requests && yarn download-ubo && yarn download-abp && yarn download-brave"
+    "prepare": "yarn download-requests && yarn download-ubo && yarn download-abp && yarn download-tsurlfilter && yarn download-brave"
   },
   "bugs": {
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "peerDependencies": {
+    "@adguard/tsurlfilter": "^0.5.24",
     "adblock-rs": "^0.3.15"
   },
   "dependencies": {

--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -146,6 +146,9 @@ async function main() {
     case 'min':
       moduleId = './blockers/minbrowser.js';
       break;
+    case 'tsurlfilter':
+      moduleId = './blockers/tsurlfilter.js';
+      break;
     default:
       console.error(`Unknown blocker ${ENGINE}`);
       process.exit(1);


### PR DESCRIPTION
Let's integrate the [@adguard/tsurlfilter](https://www.npmjs.com/package/@adguard/tsurlfilter) library into the benchmarks.