### PR TITLE
Implement hosts-only mode

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -5,6 +5,10 @@ ifeq ($(SHOW_MEMORY), 1)
 	run_options := $(run_options) --memory
 endif
 
+ifeq ($(HOSTS_ONLY), 1)
+	run_options := $(run_options) --hosts-only
+endif
+
 .PHONY: all clean deps run ubo-core adblockpluscore tsurlfilter-node adblock-rs brave cliqz cliqz-compression ublock adblockplus tsurlfilter tldts url min
 
 all: deps run

--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -80,25 +80,9 @@ function isSupportedUrl(url) {
   );
 }
 
-function looksLikeHostFilter(raw) {
-  // https://en.wikipedia.org/wiki/Hostname#Syntax
-  // The colon is included for the port number. e.g. ||localhost:8080^ could
-  // also be a host filter. The brackets are included for IPv6 addresses.
-  // e.g. ||[::1]^ could be a host filter. This also covers filters like
-  // ||localhost/ and ||localhost:
-  return /^(@@)?\|\|[a-z0-9.:[\]-]+[/:^]$/i.test(raw);
-}
-
 function loadLists() {
-  return fs.readFileSync(path.resolve(__dirname, './easylist.txt'), { encoding: 'utf-8' });
-}
-
-function filterLists(rawLists) {
-  if (FLAGS.includes('--hosts-only')) {
-    rawLists = rawLists.split(/\n/g).filter(looksLikeHostFilter).join('\n');
-  }
-
-  return rawLists;
+  const file = FLAGS.includes('--hosts-only') ? 'hosts.txt' : 'easylist.txt';
+  return fs.readFileSync(path.resolve(__dirname, file), { encoding: 'utf-8' });
 }
 
 function wait(milliseconds) {
@@ -126,7 +110,7 @@ async function memoryUsage(base = { heapUsed: 0, heapTotal: 0, }) {
 }
 
 async function main() {
-  const rawLists = filterLists(loadLists());
+  const rawLists = loadLists();
 
   let moduleId;
   switch (ENGINE) {

--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -80,8 +80,25 @@ function isSupportedUrl(url) {
   );
 }
 
+function looksLikeHostFilter(raw) {
+  // https://en.wikipedia.org/wiki/Hostname#Syntax
+  // The colon is included for the port number. e.g. ||localhost:8080^ could
+  // also be a host filter. The brackets are included for IPv6 addresses.
+  // e.g. ||[::1]^ could be a host filter. This also covers filters like
+  // ||localhost/ and ||localhost:
+  return /^(@@)?\|\|[a-z0-9.:[\]-]+[/:^]$/i.test(raw);
+}
+
 function loadLists() {
   return fs.readFileSync(path.resolve(__dirname, './easylist.txt'), { encoding: 'utf-8' });
+}
+
+function filterLists(rawLists) {
+  if (FLAGS.includes('--hosts-only')) {
+    rawLists = rawLists.split(/\n/g).filter(looksLikeHostFilter).join('\n');
+  }
+
+  return rawLists;
 }
 
 function wait(milliseconds) {
@@ -109,7 +126,7 @@ async function memoryUsage(base = { heapUsed: 0, heapTotal: 0, }) {
 }
 
 async function main() {
-  const rawLists = loadLists();
+  const rawLists = filterLists(loadLists());
 
   let moduleId;
   switch (ENGINE) {


### PR DESCRIPTION
This PR introduces a hosts-only mode. The idea is to benchmark with only "host filters." An engine could be used in this mode for DNS-level (hostnames only) or proxy-level (hostnames and port numbers) blocking.

A `hosts.txt` file is included based on [The Block List Project](https://github.com/blocklistproject/Lists#lists) (see https://github.com/cliqz-oss/adblocker/pull/2115#issuecomment-893590234).

Pass the `HOSTS_ONLY=1` option to `make` to run in hosts-only mode.