### PR TITLE
Add hosts-lookup

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -9,7 +9,7 @@ ifeq ($(HOSTS_ONLY), 1)
 	run_options := $(run_options) --hosts-only
 endif
 
-.PHONY: all clean deps run ubo-core adblockpluscore tsurlfilter-node adblock-rs brave cliqz cliqz-compression ublock adblockplus tsurlfilter tldts url min
+.PHONY: all clean deps run ubo-core adblockpluscore tsurlfilter-node adblock-rs brave cliqz cliqz-compression ublock adblockplus tsurlfilter tldts url min hosts-lookup
 
 all: deps run
 
@@ -82,6 +82,9 @@ adblockfast:
 
 min:
 	$(node_command) run.js min $(run_options)
+
+hosts-lookup:
+	$(node_command) run.js hosts-lookup $(run_options)
 
 deps:
 	npm run prepare

--- a/packages/adblocker-benchmarks/blockers/hosts-lookup.js
+++ b/packages/adblocker-benchmarks/blockers/hosts-lookup.js
@@ -1,0 +1,36 @@
+/*!
+ * Copyright (c) 2017-present Cliqz GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const { FastHostsLookup } = require('fast-hosts-lookup');
+
+const HOSTNAME_RE = /^[^:]+:(?:\/\/(?:[^\/]*@)?(\[[^\]]*\]|[^:\/]+))?/;
+function extractHostname(url) {
+  const [, hostname] = HOSTNAME_RE.exec(url) || [, ''];
+  return hostname;
+}
+
+// This is an implementation of the most basic hosts-based blocking.
+module.exports = class HostsLookup {
+  static parse(rawLists) {
+    return new HostsLookup(rawLists);
+  }
+
+  constructor(rawLists) {
+    this.lookup = new FastHostsLookup();
+
+    for (let line of rawLists.split(/\n/g)) {
+      if (line[0] === '|' && line[1] === '|' && line[line.length - 1] === '^') {
+        this.lookup.add(line.slice(2, -1));
+      }
+    }
+  }
+
+  match({ url }) {
+    return this.lookup.has(extractHostname(url));
+  }
+};

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-json": "^4.1.0",
+    "fast-hosts-lookup": "github:mjethani/fast-hosts-lookup",
     "rollup": "^2.55.1",
     "rollup-plugin-terser": "^7.0.2"
   }

--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -149,6 +149,9 @@ async function main() {
     case 'min':
       moduleId = './blockers/minbrowser.js';
       break;
+    case 'hosts-lookup':
+      moduleId = './blockers/hosts-lookup.js';
+      break;
     case 'tsurlfilter':
       moduleId = './blockers/tsurlfilter.js';
       break;


### PR DESCRIPTION
This patch adds a `hosts-lookup` target that runs a most basic hosts-based blocker to use as a baseline for comparison.

For example, hosts-based blocking could be done in a [PAC file](https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_PAC_file). It would help to know how efficient this could be.