### PR TITLE
Fix easylist.txt at runtime

### DIFF
--- a/packages/adblocker-benchmarks/blockers/adblockplus.js
+++ b/packages/adblocker-benchmarks/blockers/adblockplus.js
@@ -8,9 +8,6 @@
 
 const { contentTypes, CombinedMatcher, Filter, parseURL } = require('adblockpluscore/lib/bundle.min.cjs');
 
-// Chrome can't distinguish between OBJECT_SUBREQUEST and OBJECT requests.
-contentTypes.OBJECT_SUBREQUEST = contentTypes.OBJECT;
-
 // Map of content types reported by the browser to the respecitve content types
 // used by Adblock Plus. Other content types are simply mapped to OTHER.
 const resourceTypes = new Map(

--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -84,7 +84,17 @@ function isSupportedUrl(url) {
 
 function loadLists() {
   const filename = HOSTS_ONLY ? 'hosts.txt' : 'easylist.txt';
-  return fs.readFileSync(path.resolve(__dirname, filename), { encoding: 'utf-8' });
+  let content = fs.readFileSync(path.resolve(__dirname, filename), { encoding: 'utf-8' });
+
+  // We still use old versions of EasyList and EasyPrivacy whereas current
+  // versions no longer use $object-subrequest
+  // https://gitlab.com/eyeo/adblockplus/abc/adblockpluscore/-/issues/6
+  content = content.replace(/(?!$.*)\bobject-subrequest\b/g, 'object');
+
+  // https://github.com/cliqz-oss/adblocker/discussions/2114#discussioncomment-1133958
+  content = content.replace(/(?!$.*)\bdomain=\|/g, 'domain=');
+
+  return content;
 }
 
 function wait(milliseconds) {


### PR DESCRIPTION
Based on the discussions here: https://github.com/cliqz-oss/adblocker/discussions/2114

`run.js` fixes `easylist.txt` at runtime temporarily until we have a newer version of this file. `$object-subrequest` is replaced with `$object` and `$domain=|` is replaced with `$domain=`. There's no negative impact on performance, and both Cliqz and tsurlfilter (AdGuard's upcoming library) block more correctly now.