### PR TITLE
Move extractHostname() to utils.js

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -9,7 +9,7 @@ ifeq ($(HOSTS_ONLY), 1)
 	run_options := $(run_options) --hosts-only
 endif
 
-.PHONY: all clean deps run ubo-core adblockpluscore tsurlfilter-node adblock-rs brave cliqz cliqz-compression ublock adblockplus tsurlfilter tldts url min hosts-lookup
+.PHONY: all clean deps run ubo-core adblockpluscore tsurlfilter-node adblock-rs brave cliqz cliqz-compression ublock adblockplus tsurlfilter tldts url min re hosts-lookup
 
 all: deps run
 
@@ -82,6 +82,9 @@ adblockfast:
 
 min:
 	$(node_command) run.js min $(run_options)
+
+re:
+	$(node_command) run.js re $(run_options)
 
 hosts-lookup:
 	$(node_command) run.js hosts-lookup $(run_options)

--- a/packages/adblocker-benchmarks/blockers/hosts-lookup.js
+++ b/packages/adblocker-benchmarks/blockers/hosts-lookup.js
@@ -8,11 +8,7 @@
 
 const { FastHostsLookup } = require('fast-hosts-lookup');
 
-const HOSTNAME_RE = /^[^:]+:(?:\/\/(?:[^\/]*@)?(\[[^\]]*\]|[^:\/]+))?/;
-function extractHostname(url) {
-  const [, hostname] = HOSTNAME_RE.exec(url) || [, ''];
-  return hostname;
-}
+const { extractHostname } = require('./utils.js');
 
 // This is an implementation of the most basic hosts-based blocking.
 module.exports = class HostsLookup {

--- a/packages/adblocker-benchmarks/blockers/utils.js
+++ b/packages/adblocker-benchmarks/blockers/utils.js
@@ -6,14 +6,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-const { extractHostname } = require('./utils.js');
+'use strict';
 
-module.exports = class Re {
-  static parse() {
-    return new Re();
-  }
+const HOSTNAME_RE = /^[^:]+:(?:\/\/(?:[^\/]*@)?(\[[^\]]*\]|[^:\/]+))?/;
 
-  match({ url, frameUrl }) {
-    return extractHostname(url) && extractHostname(frameUrl);
-  }
+exports.extractHostname = function extractHostname(url) {
+  const [ , hostname = '' ] = HOSTNAME_RE.exec(url) || [ , '' ];
+  return hostname;
 };


### PR DESCRIPTION
This moves the `extractHostname()` function to `utils.js`.

There were two versions and it uses the one from `hosts-lookup.js`.

There's also a small change in that the function always returns `''` (empty string) now if the match fails, whereas previously it would return `undefined` for a URL like `turn:example.com`.