### PR TITLE
Update uBlock Origin to use npm package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "packages/adblocker-benchmarks/blockers/ublock"]
-	path = packages/adblocker-benchmarks/blockers/ublock
-	url = https://github.com/gorhill/ublock
 [submodule "packages/adblocker-benchmarks/blockers/adblockpluscore"]
 	path = packages/adblocker-benchmarks/blockers/adblockpluscore
 	url = https://github.com/adblockplus/adblockpluscore

--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -17,16 +17,13 @@ requests.json:
 	curl https://cdn.cliqz.com/adblocking/requests_top500.json.gz | gunzip \
 		| sed -e '$$ ! s/$$/,/; 1 s/^/\[/; $$ s/$$/]/' > requests.json
 
-./blockers/ublock/.git:
-	git submodule update --recursive --depth 1 --init blockers/ublock
-
 ./node_modules/@gorhill/ubo-core:
-	make -C ./blockers/ublock install-nodejs clean
+	npm install --no-save @gorhill/ubo-core
 	npx rollup ./node_modules/@gorhill/ubo-core/index.js \
 		--file ./node_modules/@gorhill/ubo-core/bundle.min.cjs --format cjs \
 		--context global --plugin terser
 
-ubo-core: ./blockers/ublock/.git ./node_modules/@gorhill/ubo-core
+ubo-core: ./node_modules/@gorhill/ubo-core
 
 ./node_modules/adblockpluscore:
 	cp -R ./blockers/adblockpluscore ./node_modules

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -26,7 +26,8 @@
   },
   "peerDependencies": {
     "@adguard/tsurlfilter": "^0.5.24",
-    "adblock-rs": "^0.3.15"
+    "adblock-rs": "^0.3.15",
+    "@gorhill/ubo-core": "^0.1.7"
   },
   "dependencies": {
     "@cliqz/adblocker": "^1.22.4",


### PR DESCRIPTION
Using the new `StaticNetFilteringEngine` class from [@gorhill/ubo-core](https://www.npmjs.com/package/@gorhill/ubo-core).