### PR TITLE
Update Adblock Plus to use npm package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/adblocker-benchmarks/blockers/adblockpluscore"]
-	path = packages/adblocker-benchmarks/blockers/adblockpluscore
-	url = https://github.com/adblockplus/adblockpluscore

--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -26,16 +26,13 @@ requests.json:
 ubo-core: ./node_modules/@gorhill/ubo-core
 
 ./node_modules/adblockpluscore:
-	cp -R ./blockers/adblockpluscore ./node_modules
+	npm install --no-save adblockpluscore
 	cp ./blockers/adblockpluscore-index.js ./node_modules/adblockpluscore/lib
 	npx rollup ./node_modules/adblockpluscore/lib/adblockpluscore-index.js \
 		--file ./node_modules/adblockpluscore/lib/bundle.min.cjs --format cjs \
 		--plugin commonjs --plugin json --plugin terser --output.exports named
 
-./blockers/adblockpluscore/.git:
-	git submodule update --recursive --depth 1 --init blockers/adblockpluscore
-
-adblockpluscore: ./blockers/adblockpluscore/.git ./node_modules/adblockpluscore
+adblockpluscore: ./node_modules/adblockpluscore
 
 ./node_modules/@adguard/tsurlfilter:
 	npm install --no-save @adguard/tsurlfilter
@@ -94,4 +91,3 @@ run: deps url tldts cliqz ublock adblockplus brave adblockfast
 clean:
 	rm -f requests.json
 	npm uninstall @adguard/tsurlfilter adblockpluscore @gorhill/ubo-core adblock-rs
-	git submodule deinit --all

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -27,6 +27,7 @@
   "peerDependencies": {
     "@adguard/tsurlfilter": "^0.5.24",
     "adblock-rs": "^0.3.15",
+    "adblockpluscore": "^0.3.1",
     "@gorhill/ubo-core": "^0.1.7"
   },
   "dependencies": {


### PR DESCRIPTION
This patch updates `Makefile` and related files to use the [npm version of the adblockpluscore Node.js package](https://www.npmjs.com/package/adblockpluscore).