### PR TITLE
Add support for exceptions to hosts-lookup

### DIFF
--- a/packages/adblocker-benchmarks/blockers/hosts-lookup.js
+++ b/packages/adblocker-benchmarks/blockers/hosts-lookup.js
@@ -20,8 +20,24 @@ module.exports = class HostsLookup {
     this.lookup = new FastHostsLookup();
 
     for (let line of rawLists.split(/\n/g)) {
-      if (line[0] === '|' && line[1] === '|' && line[line.length - 1] === '^') {
-        this.lookup.add(line.slice(2, -1));
+      line = line.trim();
+
+      if (line[line.length - 1] === '^') {
+        let exception = false;
+
+        if (line[0] === '@' && line[1] === '@') {
+          exception = true;
+          line = line.substr(2);
+        }
+
+        if (line[0] === '|' && line[1] === '|') {
+          const hostname = line.slice(2, -1);
+          if (exception) {
+            this.lookup.addException(hostname);
+          } else {
+            this.lookup.add(hostname);
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Following up from here: https://github.com/cliqz-oss/adblocker/pull/2136#discussion_r685361494

Both @adguard/tsurlfilter and @gorhill/ubo-core support exceptions in hosts-only mode, as do other libraries like adblock-rs, adblockpluscore, and @cliqz/adblocker. It makes sense that the baseline should also support exceptions.

`hosts.txt` should also include some (realistic!) exceptions but this is not part of this patch.