### PR TITLE
Install fast-hosts-lookup like other engines

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -42,6 +42,11 @@ adblockpluscore: ./node_modules/adblockpluscore
 
 tsurlfilter-node: ./node_modules/@adguard/tsurlfilter
 
+./node_modules/fast-hosts-lookup:
+	npm install --no-save mjethani/fast-hosts-lookup
+
+fast-hosts-lookup: ./node_modules/fast-hosts-lookup
+
 ./node_modules/adblock-rs:
 	npm install --no-save adblock-rs
 
@@ -90,4 +95,4 @@ run: deps url tldts cliqz ublock adblockplus brave adblockfast
 
 clean:
 	rm -f requests.json
-	npm uninstall @adguard/tsurlfilter adblockpluscore @gorhill/ubo-core adblock-rs
+	npm uninstall fast-hosts-lookup @adguard/tsurlfilter adblockpluscore @gorhill/ubo-core adblock-rs

--- a/packages/adblocker-benchmarks/package.json
+++ b/packages/adblocker-benchmarks/package.json
@@ -19,12 +19,14 @@
     "download-abp": "make adblockpluscore",
     "download-tsurlfilter": "make tsurlfilter-node",
     "download-brave": "make adblock-rs",
-    "prepare": "yarn download-requests && yarn download-ubo && yarn download-abp && yarn download-tsurlfilter && yarn download-brave"
+    "download-fast-hosts-lookup": "make fast-hosts-lookup",
+    "prepare": "yarn download-requests && yarn download-ubo && yarn download-abp && yarn download-tsurlfilter && yarn download-brave && yarn download-fast-hosts-lookup"
   },
   "bugs": {
     "url": "https://github.com/cliqz-oss/adblocker/issues"
   },
   "peerDependencies": {
+    "fast-hosts-lookup": "github:mjethani/fast-hosts-lookup#9136bb8c331ee5dba8ac1a0018552cace11e2afa",
     "@adguard/tsurlfilter": "^0.5.24",
     "adblock-rs": "^0.3.15",
     "adblockpluscore": "^0.3.1",
@@ -71,7 +73,6 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^20.0.0",
     "@rollup/plugin-json": "^4.1.0",
-    "fast-hosts-lookup": "github:mjethani/fast-hosts-lookup",
     "rollup": "^2.55.1",
     "rollup-plugin-terser": "^7.0.2"
   }


### PR DESCRIPTION
fast-hosts-lookup is not really a development-mode dependency in the same way as rollup.js.