### PR TITLE
Handle 'ping' type from puppeteer

### DIFF
--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -37,6 +37,7 @@ const WEBREQUEST_OPTIONS = {
   xhr: 'xmlhttprequest',
   fetch: 'xmlhttprequest',
   websocket: 'websocket',
+  ping: 'ping',
 
   // other
   other: 'other',
@@ -257,6 +258,10 @@ async function main() {
 
     if (!isSupportedUrl(url) || !isSupportedUrl(frameUrl)) {
       continue;
+    }
+
+    if (!(cpt in WEBREQUEST_OPTIONS)) {
+      console.warn(`Warning: Unrecognized type '${cpt}'`);
     }
 
     start = process.hrtime();


### PR DESCRIPTION
Following up from here: https://github.com/cliqz-oss/adblocker/pull/2125#issuecomment-896372761

adblock-rs crashes if the value is `undefined`.

It's not clear why we are getting [`ping` from puppeteer](https://github.com/puppeteer/puppeteer/blob/c510df8d8e52fa361c26f6db011aaa9410c8996a/docs/api.md#httprequestresourcetype) and this needs to be investigated further. It could have been something wrong with my setup.