### PR TITLE
Pass --compressed to curl

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -18,7 +18,7 @@ endif
 all: deps run
 
 requests.json:
-	curl -OH "Accept-Encoding: gzip" https://raw.githubusercontent.com/mjethani/scaling-palm-tree/06ef031aa3d2742dc7e6234f579e28a9b6d499b0/requests.json
+	curl -O --compressed https://raw.githubusercontent.com/mjethani/scaling-palm-tree/06ef031aa3d2742dc7e6234f579e28a9b6d499b0/requests.json
 
 ./node_modules/@gorhill/ubo-core:
 	npm install --no-save @gorhill/ubo-core@0.1.7


### PR DESCRIPTION
In https://github.com/cliqz-oss/adblocker/pull/2152 we updated `Makefile` to download a compressed version of `requests.json`. Unfortunately curl does not decompress it. We need to pass `--compressed` instead.