### PR TITLE
Add COMPARE=<filename> option

### DIFF
--- a/packages/adblocker-benchmarks/Makefile
+++ b/packages/adblocker-benchmarks/Makefile
@@ -4,6 +4,10 @@ ifeq ($(DEBUG), 1)
 	run_options := $(run_options) --debug
 endif
 
+ifneq ($(COMPARE), )
+	run_options := $(run_options) --compare=$(COMPARE)
+endif
+
 ifeq ($(SHOW_MEMORY), 1)
 	node_command := $(node_command) --expose-gc
 	run_options := $(run_options) --memory


### PR DESCRIPTION
This patch adds a new option for comparing the results against those of a different engine.

```
make adblockplus DEBUG=1
make ublock DEBUG=1 COMPARE=adblockplus.debug.json
```

The above produces a file called `ublock.diff.json` containing only the results that do not match.

Each entry in the output includes detail about which filter should have matched or not matched (`compareMatchDebug`) and what kind of mismatch it is (`kind`).

This should make it a lot easier to debug discrepancies in the results (see https://github.com/cliqz-oss/adblocker/pull/2125#issuecomment-896976924).