### PR TITLE
Add matchDebug() for Cliqz

### DIFF
--- a/packages/adblocker-benchmarks/blockers/cliqz-base.js
+++ b/packages/adblocker-benchmarks/blockers/cliqz-base.js
@@ -9,11 +9,12 @@
 const { FiltersEngine, Request } = require('@cliqz/adblocker/dist/adblocker.umd.min.js');
 
 module.exports = class Cliqz {
-  static parse(rawLists, enableCompression) {
+  static parse(rawLists, { enableCompression = false, debug = false } = {}) {
     return new Cliqz(FiltersEngine.parse(rawLists, {
       enableCompression,
       integrityCheck: false,
       loadCosmeticFilters: false,
+      debug,
     }));
   }
 
@@ -35,5 +36,14 @@ module.exports = class Cliqz {
       sourceUrl: frameUrl,
       type,
     })).match;
+  }
+
+  matchDebug({ url, frameUrl, type }) {
+    const { filter = null } = this.engine.match(Request.fromRawDetails({
+      url,
+      sourceUrl: frameUrl,
+      type,
+    }));
+    return filter !== null ? filter.rawLine : null;
   }
 };

--- a/packages/adblocker-benchmarks/blockers/cliqz-compression.js
+++ b/packages/adblocker-benchmarks/blockers/cliqz-compression.js
@@ -9,7 +9,7 @@
 const CliqzBase = require('./cliqz-base');
 
 module.exports = class CliqzCompression extends CliqzBase {
-  static parse(rawLists) {
-    return super.parse(rawLists, true);
+  static parse(rawLists, { debug = false } = {}) {
+    return super.parse(rawLists, { enableCompression: true, debug });
   }
 };

--- a/packages/adblocker-benchmarks/blockers/cliqz.js
+++ b/packages/adblocker-benchmarks/blockers/cliqz.js
@@ -9,7 +9,7 @@
 const CliqzBase = require('./cliqz-base');
 
 module.exports = class Cliqz extends CliqzBase {
-  static parse(rawLists) {
-    return super.parse(rawLists, false);
+  static parse(rawLists, { debug = false } = {}) {
+    return super.parse(rawLists, { debug });
   }
 };

--- a/packages/adblocker-benchmarks/run.js
+++ b/packages/adblocker-benchmarks/run.js
@@ -151,7 +151,7 @@ async function debug(moduleId, rawLists) {
     await Cls.initialize({ hostsOnly: HOSTS_ONLY });
   }
 
-  const engine = await Cls.parse(rawLists);
+  const engine = await Cls.parse(rawLists, { debug: true });
 
   for (let index = 0; index < requests.length; index += 1) {
     const { url, frameUrl, cpt } = requests[index];


### PR DESCRIPTION
This patch adds a `matchDebug()` implementation for Cliqz.