### PR TITLE
Always skip last token unless anchored

### DIFF
--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1301,7 +1301,7 @@ export default class NetworkFilter implements IFilter {
     // Get tokens from filter
     if (this.isFullRegex() === false) {
       if (this.filter !== undefined) {
-        const skipLastToken = this.isPlain() && !this.isRightAnchor();
+        const skipLastToken = !this.isRightAnchor();
         const skipFirstToken = !this.isLeftAnchor();
         tokenizeWithWildcardsInPlace(this.filter, skipFirstToken, skipLastToken, TOKENS_BUFFER);
       }


### PR DESCRIPTION
Bug https://github.com/cliqz-oss/adblocker/issues/2184

The last token in the filter `||src.ebay-us.com/*=usllpic$script,domain=ebay.com` should be ignored despite that it's a non-plain filter.