### PR TITLE
Update peer dependency on Electron

### DIFF
--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -34,7 +34,7 @@
     "test": "nyc mocha --config ../../.mocharc.js"
   },
   "peerDependencies": {
-    "electron": "^11.0.0"
+    "electron": ">11"
   },
   "dependencies": {
     "@cliqz/adblocker": "^1.22.5",

--- a/packages/adblocker-electron/package.json
+++ b/packages/adblocker-electron/package.json
@@ -34,7 +34,7 @@
     "test": "nyc mocha --config ../../.mocharc.js"
   },
   "peerDependencies": {
-    "electron": "11.x || 12.x || 13.x"
+    "electron": "^11.0.0"
   },
   "dependencies": {
     "@cliqz/adblocker": "^1.22.5",


### PR DESCRIPTION
This will hopefully make the dependency less strict for new stable and beta versions, so they can be installed without --force.