### PR TITLE
cleanup: remove unreachable code

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -799,10 +799,6 @@ export default class CosmeticFilter implements IFilter {
 
     parts.push(selector.slice(lastComaIndex + 1).trim());
 
-    if (parts.length === 0) {
-      return undefined;
-    }
-
     const args = parts
       .slice(1)
       .map((part) => {


### PR DESCRIPTION
By design, this should be unreachable. After just pushing to the array, it must be non-empty.