### PR TITLE
feat: `getTrustedInjectionRules` in `matchCosmeticFilters`

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -1159,6 +1159,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM = true,
     getRulesFromHostname = true,
     getInjectionRules,
+    getTrustedInjectionRules = true,
     getExtendedRules,
 
     callerContext,
@@ -1174,6 +1175,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
     getRulesFromDOM?: boolean;
     getRulesFromHostname?: boolean;
     getInjectionRules?: boolean;
+    getTrustedInjectionRules?: boolean;
     getExtendedRules?: boolean;
 
     callerContext?: any | undefined;
@@ -1297,6 +1299,13 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       );
 
       if (filter.isScriptInject()) {
+        // There should be no exception as the flag is explicitly set
+        if (
+          getTrustedInjectionRules === false &&
+          this.resources.scriptletsByName.get(filter.getScriptName())
+        ) {
+          continue;
+        }
         if (injectionsDisabledFilter !== undefined) {
           exception = injectionsDisabledFilter;
         }

--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -714,6 +714,18 @@ export default class CosmeticFilter implements IFilter {
     return tokens;
   }
 
+  public getScriptName(): string {
+    if (this.scriptletDetails !== undefined) {
+      return this.scriptletDetails.name;
+    }
+
+    const selector = this.getSelector();
+    const firstDelimiterIndex = selector.indexOf(',');
+    const openerIndex = selector.indexOf('(');
+
+    return selector.slice(openerIndex, firstDelimiterIndex);
+  }
+
   public parseScript(): { name: string; args: string[] } | undefined {
     if (this.scriptletDetails !== undefined) {
       return this.scriptletDetails;

--- a/packages/adblocker/src/resources.ts
+++ b/packages/adblocker/src/resources.ts
@@ -247,7 +247,7 @@ export default class Resources {
   public readonly checksum: string;
   public readonly scriptlets: Scriptlet[];
   public readonly resources: Resource[];
-  private readonly scriptletsByName: Map<string, Scriptlet>;
+  public readonly scriptletsByName: Map<string, Scriptlet>;
   private readonly resourcesByName: Map<string, Resource>;
   private readonly scriptletsCache: Map<string, string>;
 


### PR DESCRIPTION
refs https://github.com/ghostery/adblocker/issues/5248

This pull request proposes supporting runtime check for `getTrustedInjectionRules`. It's not per filter list because we don't have filter list attribution yet but in the per filter level. This is not for review.