### PR TITLE
fix(adblocker): ensure case insensitive matching

### DIFF
--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -2072,6 +2072,7 @@ export function isAnchoredByHostname(
  */
 function checkPattern(filter: NetworkFilter, request: Request): boolean {
   const pattern = filter.getFilter();
+  const url = request.normalizedUrl;
 
   if (filter.isHostnameAnchor() === true) {
     // Make sure request is anchored by hostname before proceeding to matching
@@ -2091,15 +2092,13 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
       // ||pattern*^
       return filter
         .getRegex()
-        .test(request.url.slice(request.url.indexOf(filterHostname) + filterHostname.length));
+        .test(url.slice(url.indexOf(filterHostname) + filterHostname.length));
     } else if (filter.isRightAnchor() && filter.isLeftAnchor()) {
       // |||pattern|
       // Since this is not a regex, the filter pattern must follow the hostname
       // with nothing in between. So we extract the part of the URL following
       // after hostname and will perform the matching on it.
-      const urlAfterHostname = request.url.slice(
-        request.url.indexOf(filterHostname) + filterHostname.length,
-      );
+      const urlAfterHostname = url.slice(url.indexOf(filterHostname) + filterHostname.length);
 
       // Since it must follow immediatly after the hostname and be a suffix of
       // the URL, we conclude that filter must be equal to the part of the
@@ -2119,7 +2118,7 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
         );
       } else {
         // pattern|
-        return request.url.endsWith(pattern);
+        return url.endsWith(pattern);
       }
     } else if (filter.isLeftAnchor()) {
       // ||pattern + left-anchor => This means that a plain pattern needs to appear
@@ -2127,10 +2126,7 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
       // Since this is not a regex, the filter pattern must follow the hostname
       // with nothing in between. So we extract the part of the URL following
       // after hostname and will perform the matching on it.
-      return request.url.startsWith(
-        pattern,
-        request.url.indexOf(filterHostname) + filterHostname.length,
-      );
+      return url.startsWith(pattern, url.indexOf(filterHostname) + filterHostname.length);
     }
 
     if (filter.hasFilter() === false) {
@@ -2138,22 +2134,19 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
     }
 
     // We consider this a match if the plain patter (i.e.: filter) appears anywhere.
-    return (
-      request.url.indexOf(pattern, request.url.indexOf(filterHostname) + filterHostname.length) !==
-      -1
-    );
+    return url.indexOf(pattern, url.indexOf(filterHostname) + filterHostname.length) !== -1;
   } else if (filter.isRegex()) {
     // pattern*^
-    return filter.getRegex().test(request.url);
+    return filter.getRegex().test(url);
   } else if (filter.isLeftAnchor() && filter.isRightAnchor()) {
     // |pattern|
-    return request.url === pattern;
+    return url === pattern;
   } else if (filter.isLeftAnchor()) {
     // |pattern
-    return request.url.startsWith(pattern);
+    return url.startsWith(pattern);
   } else if (filter.isRightAnchor()) {
     // pattern|
-    return request.url.endsWith(pattern);
+    return url.endsWith(pattern);
   }
 
   // pattern
@@ -2161,7 +2154,7 @@ function checkPattern(filter: NetworkFilter, request: Request): boolean {
     return true;
   }
 
-  return request.url.indexOf(pattern) !== -1;
+  return url.indexOf(pattern) !== -1;
 }
 
 function checkOptions(filter: NetworkFilter, request: Request): boolean {

--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -292,8 +292,6 @@ export default class Request<T = any | undefined> {
     type = 'main_frame',
     _originalRequestDetails,
   }: Partial<RequestInitialization<T>>): Request<T> {
-    url = url.toLowerCase();
-
     if (hostname === undefined || domain === undefined) {
       const parsed = parse(url, TLDTS_OPTIONS);
       hostname = hostname || parsed.hostname || '';
@@ -337,6 +335,7 @@ export default class Request<T = any | undefined> {
   public readonly id: string;
   public readonly tabId: number;
   public readonly url: string;
+  public readonly normalizedUrl: string;
   public readonly hostname: string;
   public readonly domain: string;
 
@@ -369,6 +368,7 @@ export default class Request<T = any | undefined> {
     this.type = type;
 
     this.url = url;
+    this.normalizedUrl = url.toLowerCase();
     this.hostname = hostname;
     this.domain = domain;
 
@@ -448,7 +448,7 @@ export default class Request<T = any | undefined> {
       // Add token corresponding to request type
       TOKENS_BUFFER.push(NORMALIZED_TYPE_TOKEN[this.type]);
 
-      tokenizeNoSkipInPlace(this.url, TOKENS_BUFFER);
+      tokenizeNoSkipInPlace(this.normalizedUrl, TOKENS_BUFFER);
 
       this.tokens = TOKENS_BUFFER.slice();
     }

--- a/packages/adblocker/test/data/requests.ts
+++ b/packages/adblocker/test/data/requests.ts
@@ -52921,4 +52921,12 @@ export default [
     type: 'script',
     url: 'https://www1.swatchseries.to/public/js/bootstrap-modal.js',
   },
+  {
+    filters: [
+      '||assets.adobedtm.com/extensions/*/AppMeasurement_Module_ActivityMap.min.js$script,domain=euronews.com',
+    ],
+    sourceUrl: 'https://euronews.com',
+    type: 'script',
+    url: 'https://assets.adobedtm.com/extensions/EP31dbb9c60e404ba1aa6e746d49be6f29/AppMeasurement_Module_ActivityMap.min.js',
+  },
 ];

--- a/packages/adblocker/test/request.test.ts
+++ b/packages/adblocker/test/request.test.ts
@@ -29,14 +29,6 @@ describe('#Request', () => {
       });
     });
 
-    it('converts url to lower case', () => {
-      expect(Request.fromRawDetails({ url: 'https://sub.FOO.cOm/bar' })).to.deep.include({
-        domain: 'foo.com',
-        hostname: 'sub.foo.com',
-        url: 'https://sub.foo.com/bar',
-      });
-    });
-
     it('parses url', () => {
       expect(Request.fromRawDetails({ url: 'https://sub.foo.com/bar' })).to.deep.include({
         domain: 'foo.com',


### PR DESCRIPTION
fixes https://github.com/ghostery/broken-page-reports/issues/1812

Request `url`, may be used for different purposes, but for purpose of matching it should be always lower cased. For that reason, we introduce a new request property `normalizedUrl` which will be used for matching purposes only. 