### PR TITLE
fix: `this.hasHostnameConstraint()` is always `true`

### DIFF
--- a/packages/adblocker/src/filters/cosmetic.ts
+++ b/packages/adblocker/src/filters/cosmetic.ts
@@ -584,7 +584,7 @@ export default class CosmeticFilter implements IFilter {
     }
 
     // No `hostname` available but this filter has some constraints on hostname.
-    if (!hostname && this.hasHostnameConstraint()) {
+    if (!hostname) {
       return false;
     }
 


### PR DESCRIPTION
Derived from #5104, this pull request removes unnecessary condition.