### PR TITLE
Bump engine version to 812

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -38,7 +38,7 @@ import { ICategory } from './metadata/categories.js';
 import { IOrganization } from './metadata/organizations.js';
 import { IPattern } from './metadata/patterns.js';
 
-export const ENGINE_VERSION = 811;
+export const ENGINE_VERSION = 812;
 
 function findApplicableHideException(filters: NetworkFilter[]): NetworkFilter | undefined {
   if (filters.length === 0) {


### PR DESCRIPTION
This fixes ghostery-extension users not being able to get a proper filter updates and potentially crash the ad-blocking. Since we're relying on the `ENGINE_VERSION` constant defined in `engine.ts` to deliver the correct scheme of the engine binary, it's necessary to update the constant in the right time.

From the last release #5104 , the change to the engine binary scheme happened by updating the `computeFilterId` function which causes side-effects to other components relying on as well.

From that, our backend also confused if those versions are compatible or not and published the specific version to the all adblocker engine versions using same `ENGINE_VERSION` constant.