### PR TITLE
test: migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bench/.bench.json
 .yarn/
 .tshy/
 .tshy-build/
+.migration-test/


### PR DESCRIPTION
This adds tests to cover an incident happened with last adblocker release: #5104. Please, see additional details on #5361 and refer to the following comment.

```
    // These tests are to describe side-effects of engine binary incompatibilities
    // between multiple adblocker library versions. If you're seeing errors, you
    // should increase the `ENGINE_VERSION` variable.
```