### PR TITLE
fix(adblocker): limit maxNgram for network-hostname codebook

### DIFF
--- a/packages/adblocker/tools/generate_compression_codebooks.ts
+++ b/packages/adblocker/tools/generate_compression_codebooks.ts
@@ -129,6 +129,8 @@ async function generateCodebook(kind: string): Promise<string[]> {
     options.maxNgram = 12;
   } else if (kind === 'raw-network') {
     options.maxNgram = 11;
+  } else if (kind === 'network-hostname') {
+    options.maxNgram = 15;
   } else if (kind === 'cosmetic-selector') {
     options.maxNgram = 26;
   }


### PR DESCRIPTION
The n-gram count with default maxNgram (82) exceeds V8 Map limit of 2^24 entries, causing codebook generation to fail with 'Map maximum size exceeded'.