### PR TITLE
ci: check engine version and enforce different pull request labels

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -27,8 +27,8 @@ jobs:
     - uses: yogevbd/enforce-label-action@2.1.0
       if: steps.DIFF_ENGINE_VERSION.outputs.IS_CHANGED == 'TRUE'
       with:
-        REQUIRED_LABELS_ANY: "PR: Breaking Change :boom:,PR: New Feature :rocket:,PR: Performance :running_woman:"
-        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label: PR: Breaking Change :boom:, PR: New Feature :rocket:, PR: Performance :running_woman:"
+        REQUIRED_LABELS_ANY: "PR: Breaking Change :boom:,PR: New Feature :rocket:,PR: Performance :running_woman:,PR: Internal :house:"
+        REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label: PR: Breaking Change :boom:, PR: New Feature :rocket:, PR: Performance :running_woman:, PR: Internal :house:"
 
     - uses: yogevbd/enforce-label-action@2.1.0
       if: steps.DIFF_ENGINE_VERSION.outputs.IS_CHANGED == ''


### PR DESCRIPTION
From last incident with ENGINE_VERSION: #5104, the follow-up release #5361 was also causing a versioning issue. Due to the structure, it should always bump minor version at minimum (not the patch version).

This improves enforcement of the pull request label by checking ENGINE_VERSION diff.