### PR TITLE
perf: delegation check for pseudo selector and reusible xpath expressions

### DIFF
--- a/packages/adblocker-extended-selectors/src/eval.ts
+++ b/packages/adblocker-extended-selectors/src/eval.ts
@@ -428,7 +428,7 @@ function traverse(root: Element, selectors: AST[]): Element[] {
  * Check if the selector is delegating the traversal process to the external method.
  * @param selector The pseudo class selector
  */
-export function isDelegatedPseudoClass(selector: PseudoClass): boolean {
+function isDelegatedPseudoClass(selector: PseudoClass): boolean {
   if (selector.name === 'xpath') {
     return true;
   }


### PR DESCRIPTION
fixes #5381

From the nytimes.com breakage https://github.com/ghostery/broken-page-reports/issues/2069, `:xpath` pseudo class selector is known for creating number of executions. Here, I found two improvements could be made: (a) reusing xpath expressions (b) incorrectly pushing all elements to the result candidates from `querySelectorAll` method.

## Delegation check

The second one: **delegation check for pseudo selector** includes logical changes and this requires a strict review. It might be seen as a temporal fix for the issue as the same issue may happen again with different selector. Also, it exposes the unoptimised code path from the whole evaluation process.

Looking at the `querySelectorAll` method, you can see it will run `element.querySelectorAll('*')` to load all elements into the candidates list. This creates a lot of duplicated query due to the nature of xpath evaluation which handles all the elements under the given `element`.

`isDelegatedPseudoClass` method create a way to check if the method is delegating the query into another method such as DOM query or xpath query. When the selector is marked as "delegated" by this method, it means the query will be outsourced and the delegating entity is responsible for searching all of the child nodes.

https://github.com/ghostery/adblocker/blob/master/packages/adblocker-extended-selectors/src/eval.ts#L463-L476

### Further directions

It seems like `:has` also can be extremely slow when the specific conditions are met.

## Measurement

The measurement were done manually but the actual behaviours are demonstrated as below.

### In case of `:xpath(query)`

1. `packages/adblocker-extended-selectors/src/eval.ts:querySelectorAll` is called with `document.documentElement` and `[PseudoClass{name: 'xpath'}]`.
2. From `if (selector.type === 'pseudo-class')`, `element.querySelectorAll('*')` is called and each element is passed to `traverse()` with the given selector.

In section 2, it shouldn't be querying more than one time since the evaluation of `xpath` on `document.documentElement` must include all the results coming from the view of its children. Especially here, it shouldn't query as many as the number of elements in the document.