### PR TITLE
Quick fix asset generation

### DIFF
--- a/patches/@remusao+counter+2.1.0.patch
+++ b/patches/@remusao+counter+2.1.0.patch
@@ -1,15 +1,18 @@
 diff --git a/node_modules/@remusao/counter/dist/commonjs/index.js b/node_modules/@remusao/counter/dist/commonjs/index.js
-index 48cb504..756bfcd 100644
+index 48cb504..e269364 100644
 --- a/node_modules/@remusao/counter/dist/commonjs/index.js
 +++ b/node_modules/@remusao/counter/dist/commonjs/index.js
-@@ -1,29 +1,56 @@
+@@ -1,29 +1,59 @@
  "use strict";
  Object.defineProperty(exports, "__esModule", { value: true });
  exports.Counter = void 0;
++const NUM_SHARDS = 256;
 +function getShardKey(key) {
-+    if (key.length === 0) return '';
-+    if (key.length === 1) return key;
-+    return key.slice(0, 2);
++    let hash = 5381;
++    for (let i = 0; i < key.length; i++) {
++        hash = ((hash << 5) + hash) ^ key.charCodeAt(i);
++    }
++    return (hash >>> 0) % NUM_SHARDS;
 +}
  class Counter {
      constructor(init) {
@@ -65,7 +68,7 @@ index 48cb504..756bfcd 100644
          if (count === undefined) {
              return 0;
          }
-@@ -33,7 +60,7 @@ class Counter {
+@@ -33,7 +63,7 @@ class Counter {
          if (n < 0) {
              throw new Error(`Counter#incr only accepts positive values: ${n}`);
          }
@@ -74,7 +77,7 @@ index 48cb504..756bfcd 100644
          return this;
      }
      decr(key, n = 1) {
-@@ -42,19 +69,22 @@ class Counter {
+@@ -42,19 +72,22 @@ class Counter {
          }
          const count = this.get(key);
          if (count <= n) {
@@ -106,14 +109,17 @@ index 48cb504..756bfcd 100644
 -//# sourceMappingURL=index.js.map
 \ No newline at end of file
 diff --git a/node_modules/@remusao/counter/dist/esm/index.js b/node_modules/@remusao/counter/dist/esm/index.js
-index bbcd9bb..7e6be77 100644
+index bbcd9bb..8528ff4 100644
 --- a/node_modules/@remusao/counter/dist/esm/index.js
 +++ b/node_modules/@remusao/counter/dist/esm/index.js
-@@ -1,26 +1,54 @@
+@@ -1,26 +1,57 @@
++const NUM_SHARDS = 256;
 +function getShardKey(key) {
-+    if (key.length === 0) return '';
-+    if (key.length === 1) return key;
-+    return key.slice(0, 2);
++    let hash = 5381;
++    for (let i = 0; i < key.length; i++) {
++        hash = ((hash << 5) + hash) ^ key.charCodeAt(i);
++    }
++    return (hash >>> 0) % NUM_SHARDS;
 +}
 +
  export class Counter {
@@ -170,7 +176,7 @@ index bbcd9bb..7e6be77 100644
          if (count === undefined) {
              return 0;
          }
-@@ -30,7 +58,7 @@ export class Counter {
+@@ -30,7 +61,7 @@ export class Counter {
          if (n < 0) {
              throw new Error(`Counter#incr only accepts positive values: ${n}`);
          }
@@ -179,7 +185,7 @@ index bbcd9bb..7e6be77 100644
          return this;
      }
      decr(key, n = 1) {
-@@ -39,18 +67,21 @@ export class Counter {
+@@ -39,18 +70,21 @@ export class Counter {
          }
          const count = this.get(key);
          if (count <= n) {


### PR DESCRIPTION
- Patch @remusao/counter to use sharded Maps, bypassing V8's ~16.7M entry Map limit
- Fixes RangeError: Map maximum size exceeded when running yarn codebook-raw-network

If this approach will work, we should update the `@remusao/counter` and remove the patch.

Failed CI run https://github.com/ghostery/adblocker/actions/runs/21630440543/job/62341486792