### PR TITLE
feat: attribute provider

### DIFF
--- a/packages/adblocker/src/engine/metadata/attributes.ts
+++ b/packages/adblocker/src/engine/metadata/attributes.ts
@@ -1,0 +1,238 @@
+/*!
+ * Copyright (c) 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { sizeOfByte, sizeOfLength, sizeOfUTF8, StaticDataView } from '../../data-view.js';
+
+type FilterId = number & { __hint?: 'filterId' };
+type LineNumber = number & { __hint?: 'lineNumber' };
+
+/**
+ * List holds the actual line number data for filter ID.
+ */
+export type List = Map<FilterId, LineNumber>;
+
+/**
+ * Chunk is an intermediate data structure to share code path in
+ * the serialisation size calculation and data serialisation. For
+ * efficient data storage, it maintains sorted array of filter ID
+ * using the line number as an offset.
+ *
+ * [I | ... | K | X | ...]
+ *  ^----------------------- I: Length of chunks
+ *      ^------------------- UTF8 chunk for the list name
+ *            ^------------- K: Line number offset for fellow IDs
+ *                ^--------- X: Length of filter IDs
+ */
+type Chunk = [LineNumber, FilterId[]];
+
+function transformListIntoChunks(list: List): Chunk[] {
+  const enum ListRef {
+    FilterId = 0,
+    LineNumber = 1,
+  }
+
+  const sorted = [...list.entries()].sort(function ([, a], [, b]) {
+    return a - b;
+  });
+  const chunks: Chunk[] = [];
+  for (let i = 0, k = 0; i < sorted.length; i = ++k) {
+    const [filterId, lineNumber] = sorted[i];
+    const chunk: FilterId[] = [filterId];
+    for (k = i; k < sorted.length; k++) {
+      if (lineNumber + 1 !== sorted[k][ListRef.LineNumber]) {
+        break;
+      }
+      chunk.push(sorted[k][ListRef.FilterId]);
+    }
+    chunks.push([lineNumber, chunk]);
+  }
+  return chunks;
+}
+
+/**
+ * IAttribute is the final data structure returned to the user.
+ * It belongs to SourceMap, so the user can access to per-filter
+ * level attribute quick. It's designed to be independant from
+ * the engine resources such as `engine.lists`.
+ */
+export interface IAttribute {
+  locations: Array<{
+    name: string;
+    lineNumber: LineNumber;
+  }>;
+}
+
+export type SourceMap = Map<FilterId, IAttribute>;
+
+function mergeAttribute(root: IAttribute, leaf: IAttribute): void {
+  for (const location of leaf.locations) {
+    const redundantIndex = root.locations.findIndex(function (existingLocation) {
+      return location.name === existingLocation.name;
+    });
+    if (redundantIndex === -1) {
+      root.locations.push(location);
+    } else {
+      // Replace the existing metadata
+      root.locations.splice(redundantIndex, 1, location);
+    }
+  }
+}
+
+function generateSourceMap(lists: Map<string, List>): SourceMap {
+  const sourceMap: SourceMap = new Map();
+  for (const [name, map] of lists) {
+    for (const [filterId, lineNumber] of map) {
+      const root = sourceMap.get(filterId);
+      const leaf = {
+        locations: [{ name, lineNumber }],
+      };
+      if (root === undefined) {
+        sourceMap.set(filterId, leaf);
+      } else {
+        mergeAttribute(root, leaf);
+      }
+    }
+  }
+
+  return sourceMap;
+}
+
+export class AttributeProvider {
+  public static deserialize(view: StaticDataView): AttributeProvider {
+    const lists: Map<string, List> = new Map();
+    const listSize = view.getLength();
+    for (let i = 0; i < listSize; i++) {
+      const list: List = new Map();
+      const name = view.getUTF8();
+      const chunkSize = view.getLength();
+      for (let k = 0; k < chunkSize; k++) {
+        const offset = view.getLength();
+        const filterIdsSize = view.getLength();
+        for (let z = 0; z < filterIdsSize; z++) {
+          list.set(view.getUint32(), offset + z);
+        }
+      }
+      lists.set(name, list);
+    }
+
+    const sourceMap = generateSourceMap(lists);
+
+    return new this({ lists, sourceMap });
+  }
+
+  public readonly lists: Map<string, List>;
+  private readonly sourceMap: SourceMap;
+
+  constructor({
+    lists = new Map(),
+    sourceMap = new Map(),
+  }: {
+    lists?: Map<string, List> | undefined;
+    sourceMap?: SourceMap | undefined;
+  }) {
+    this.lists = lists;
+    this.sourceMap = sourceMap;
+  }
+
+  private upsert(filterId: FilterId, leaf: IAttribute) {
+    const root = this.sourceMap.get(filterId);
+    if (root === undefined) {
+      this.sourceMap.set(filterId, leaf);
+    } else {
+      mergeAttribute(root, leaf);
+    }
+  }
+
+  public importFilter(filterId: FilterId, attribute: IAttribute) {
+    for (const { name, lineNumber } of attribute.locations) {
+      const list = this.lists.get(name);
+      if (list === undefined) {
+        this.lists.set(name, new Map([[filterId, lineNumber]]));
+      } else {
+        list.set(filterId, lineNumber);
+      }
+
+      this.upsert(filterId, {
+        locations: [{ name, lineNumber }],
+      });
+    }
+  }
+
+  public dropFilter(filterId: FilterId) {
+    for (const [, map] of this.lists) {
+      map.delete(filterId);
+    }
+
+    this.sourceMap.delete(filterId);
+  }
+
+  public importList(name: string, map: List) {
+    this.lists.set(name, map);
+
+    for (const [filterId, lineNumber] of map) {
+      this.upsert(filterId, {
+        locations: [{ name, lineNumber }],
+      });
+    }
+  }
+
+  public dropList(name: string) {
+    this.lists.delete(name);
+
+    for (const [filterId, attribute] of this.sourceMap) {
+      if (attribute.locations.length === 1) {
+        this.sourceMap.delete(filterId);
+      } else {
+        const index = attribute.locations.findIndex(function (location) {
+          return location.name === name;
+        });
+        if (index !== -1) {
+          attribute.locations.splice(index, 1);
+        }
+      }
+    }
+  }
+
+  public getAttribute(filterId: FilterId): IAttribute | undefined {
+    return this.sourceMap.get(filterId);
+  }
+
+  public getSerializedSize(): number {
+    let estimate: number = 0;
+
+    estimate += sizeOfLength(this.lists.size);
+    for (const [name, list] of this.lists) {
+      const chunks = transformListIntoChunks(list);
+      estimate += sizeOfUTF8(name);
+      estimate += sizeOfLength(chunks.length);
+      for (const [offset, filterIds] of chunks) {
+        estimate += sizeOfLength(offset);
+        estimate += sizeOfLength(filterIds.length);
+        estimate += sizeOfByte() * 4 * filterIds.length;
+      }
+    }
+
+    return estimate;
+  }
+
+  public serialize(view: StaticDataView): void {
+    view.pushLength(this.lists.size);
+    for (const [name, list] of this.lists) {
+      const chunks = transformListIntoChunks(list);
+      view.pushUTF8(name);
+      view.pushLength(chunks.length);
+      for (const [offset, filterIds] of chunks) {
+        view.pushLength(offset);
+        view.pushLength(filterIds.length);
+        for (const filterId of filterIds) {
+          view.pushUint32(filterId);
+        }
+      }
+    }
+  }
+}

--- a/packages/adblocker/src/engine/metadata/attributes.ts
+++ b/packages/adblocker/src/engine/metadata/attributes.ts
@@ -43,7 +43,7 @@ function transformListIntoChunks(list: List): Chunk[] {
   for (let i = 0, k = 0; i < sorted.length; i = ++k) {
     const [filterId, lineNumber] = sorted[i];
     const chunk: FilterId[] = [filterId];
-    for (k = i; k < sorted.length; k++) {
+    for (k = i + 1; k < sorted.length; k++) {
       if (lineNumber + 1 !== sorted[k][ListRef.LineNumber]) {
         break;
       }

--- a/packages/adblocker/src/engine/metadata/attributes.ts
+++ b/packages/adblocker/src/engine/metadata/attributes.ts
@@ -43,6 +43,7 @@ function transformListIntoChunks(list: List): Chunk[] {
   for (let i = 0, k = 0; i < sorted.length; i = ++k) {
     const [filterId, lineNumber] = sorted[i];
     const chunk: FilterId[] = [filterId];
+    // Start at i + 1 or every chunk stays size 1.
     for (k = i + 1; k < sorted.length; k++) {
       if (lineNumber + 1 !== sorted[k][ListRef.LineNumber]) {
         break;
@@ -95,6 +96,7 @@ export class AttributeProvider {
 
   constructor({ lists = new Map() }: { lists?: Map<string, List> | undefined }) {
     this.lists = lists;
+    // Cache only; `lists` is the only one serialised.
     this.reverseIndex = new Map();
   }
 
@@ -112,8 +114,30 @@ export class AttributeProvider {
       if (index === -1) {
         currentAttribute.locations.push(newLocation);
       } else {
-        currentAttribute.locations[index].lineNumber = newLocation.lineNumber;
+        currentAttribute.locations.splice(index, 1, newLocation);
       }
+    }
+  }
+
+  private unlink(filterId: FilterId, name: string) {
+    const attribute = this.reverseIndex.get(filterId);
+    if (attribute === undefined) {
+      return;
+    }
+
+    const index = attribute.locations.findIndex(function (location) {
+      return location.name === name;
+    });
+    if (index === -1) {
+      return;
+    }
+
+    // If we have a valid index and the count of locations is 1,
+    // we just remove the filter.
+    if (attribute.locations.length === 1) {
+      this.reverseIndex.delete(filterId);
+    } else {
+      attribute.locations.splice(index, 1);
     }
   }
 
@@ -142,52 +166,19 @@ export class AttributeProvider {
     }
 
     list.delete(filterId);
-
-    const attribute = this.reverseIndex.get(filterId);
-    if (attribute === undefined) {
-      return;
-    }
-
-    const index = attribute.locations.findIndex(function (location) {
-      return location.name === name;
-    });
-    if (index === -1) {
-      return;
-    }
-
-    if (attribute.locations.length === 1) {
-      this.reverseIndex.delete(filterId);
-    } else {
-      attribute.locations.splice(index, 1);
-    }
+    this.unlink(filterId, name);
   }
 
   public addList(name: string, newList: List) {
     const currentList = this.lists.get(name);
     if (currentList !== undefined) {
+      // Drop stale entries before overwriting this list.
       for (const [filterId] of currentList) {
         if (newList.has(filterId)) {
           continue;
         }
 
-        const attribute = this.reverseIndex.get(filterId);
-        if (attribute === undefined) {
-          this.reverseIndex.delete(filterId);
-          continue;
-        }
-
-        const index = attribute.locations.findIndex(function (location) {
-          return location.name === name;
-        });
-        if (index === -1) {
-          continue;
-        }
-
-        if (attribute.locations.length === 1) {
-          this.reverseIndex.delete(filterId);
-        } else {
-          attribute.locations.splice(index, 1);
-        }
+        this.unlink(filterId, name);
       }
     }
 
@@ -202,6 +193,7 @@ export class AttributeProvider {
       });
     }
 
+    // Keep `lists` in sync with reverseIndex updates.
     this.lists.set(name, newList);
   }
 
@@ -212,24 +204,9 @@ export class AttributeProvider {
     }
 
     for (const [filterId] of list) {
-      const attribute = this.reverseIndex.get(filterId);
-      if (attribute === undefined) {
-        continue;
-      }
-
-      const index = attribute.locations.findIndex(function (location) {
-        return location.name === name;
-      });
-      if (index === -1) {
-        continue;
-      }
-
-      if (attribute.locations.length === 1) {
-        this.reverseIndex.delete(filterId);
-      } else {
-        attribute.locations.splice(index, 1);
-      }
+      this.unlink(filterId, name);
     }
+
     this.lists.delete(name);
   }
 

--- a/packages/adblocker/src/engine/metadata/attributes.ts
+++ b/packages/adblocker/src/engine/metadata/attributes.ts
@@ -69,39 +69,6 @@ export interface IAttribute {
 
 export type SourceMap = Map<FilterId, IAttribute>;
 
-function mergeAttribute(root: IAttribute, leaf: IAttribute): void {
-  for (const location of leaf.locations) {
-    const redundantIndex = root.locations.findIndex(function (existingLocation) {
-      return location.name === existingLocation.name;
-    });
-    if (redundantIndex === -1) {
-      root.locations.push(location);
-    } else {
-      // Replace the existing metadata
-      root.locations.splice(redundantIndex, 1, location);
-    }
-  }
-}
-
-function generateSourceMap(lists: Map<string, List>): SourceMap {
-  const sourceMap: SourceMap = new Map();
-  for (const [name, map] of lists) {
-    for (const [filterId, lineNumber] of map) {
-      const root = sourceMap.get(filterId);
-      const leaf = {
-        locations: [{ name, lineNumber }],
-      };
-      if (root === undefined) {
-        sourceMap.set(filterId, leaf);
-      } else {
-        mergeAttribute(root, leaf);
-      }
-    }
-  }
-
-  return sourceMap;
-}
-
 export class AttributeProvider {
   public static deserialize(view: StaticDataView): AttributeProvider {
     const lists: Map<string, List> = new Map();
@@ -120,86 +87,171 @@ export class AttributeProvider {
       lists.set(name, list);
     }
 
-    const sourceMap = generateSourceMap(lists);
-
-    return new this({ lists, sourceMap });
+    return new this({ lists });
   }
 
   public readonly lists: Map<string, List>;
-  private readonly sourceMap: SourceMap;
+  public readonly reverseIndex: Map<FilterId, IAttribute>;
 
-  constructor({
-    lists = new Map(),
-    sourceMap = new Map(),
-  }: {
-    lists?: Map<string, List> | undefined;
-    sourceMap?: SourceMap | undefined;
-  }) {
+  constructor({ lists = new Map() }: { lists?: Map<string, List> | undefined }) {
     this.lists = lists;
-    this.sourceMap = sourceMap;
+    this.reverseIndex = new Map();
   }
 
-  private upsert(filterId: FilterId, leaf: IAttribute) {
-    const root = this.sourceMap.get(filterId);
-    if (root === undefined) {
-      this.sourceMap.set(filterId, leaf);
-    } else {
-      mergeAttribute(root, leaf);
+  private upsert(filterId: FilterId, newAttribute: IAttribute) {
+    const currentAttribute = this.reverseIndex.get(filterId);
+    if (currentAttribute === undefined) {
+      this.reverseIndex.set(filterId, newAttribute);
+      return;
     }
-  }
 
-  public importFilter(filterId: FilterId, attribute: IAttribute) {
-    for (const { name, lineNumber } of attribute.locations) {
-      const list = this.lists.get(name);
-      if (list === undefined) {
-        this.lists.set(name, new Map([[filterId, lineNumber]]));
+    for (const newLocation of newAttribute.locations) {
+      const index = currentAttribute.locations.findIndex(function (location) {
+        return location.name === newLocation.name;
+      });
+      if (index === -1) {
+        currentAttribute.locations.push(newLocation);
       } else {
-        list.set(filterId, lineNumber);
+        currentAttribute.locations[index].lineNumber = newLocation.lineNumber;
       }
-
-      this.upsert(filterId, {
-        locations: [{ name, lineNumber }],
-      });
     }
   }
 
-  public dropFilter(filterId: FilterId) {
-    for (const [, map] of this.lists) {
-      map.delete(filterId);
+  public addFilter(name: string, filterId: FilterId, lineNumber: LineNumber) {
+    const list = this.lists.get(name);
+    if (list === undefined) {
+      this.lists.set(name, new Map([[filterId, lineNumber]]));
+    } else {
+      list.set(filterId, lineNumber);
     }
 
-    this.sourceMap.delete(filterId);
+    this.upsert(filterId, {
+      locations: [
+        {
+          name,
+          lineNumber,
+        },
+      ],
+    });
   }
 
-  public importList(name: string, map: List) {
-    this.lists.set(name, map);
+  public removeFilter(name: string, filterId: FilterId) {
+    const list = this.lists.get(name);
+    if (list === undefined) {
+      return;
+    }
 
-    for (const [filterId, lineNumber] of map) {
-      this.upsert(filterId, {
-        locations: [{ name, lineNumber }],
-      });
+    list.delete(filterId);
+
+    const attribute = this.reverseIndex.get(filterId);
+    if (attribute === undefined) {
+      return;
+    }
+
+    const index = attribute.locations.findIndex(function (location) {
+      return location.name === name;
+    });
+    if (index === -1) {
+      return;
+    }
+
+    if (attribute.locations.length === 1) {
+      this.reverseIndex.delete(filterId);
+    } else {
+      attribute.locations.splice(index, 1);
     }
   }
 
-  public dropList(name: string) {
-    this.lists.delete(name);
+  public addList(name: string, newList: List) {
+    const currentList = this.lists.get(name);
+    if (currentList !== undefined) {
+      for (const [filterId] of currentList) {
+        if (newList.has(filterId)) {
+          continue;
+        }
 
-    for (const [filterId, attribute] of this.sourceMap) {
-      if (attribute.locations.length === 1) {
-        this.sourceMap.delete(filterId);
-      } else {
+        const attribute = this.reverseIndex.get(filterId);
+        if (attribute === undefined) {
+          this.reverseIndex.delete(filterId);
+          continue;
+        }
+
         const index = attribute.locations.findIndex(function (location) {
           return location.name === name;
         });
-        if (index !== -1) {
+        if (index === -1) {
+          continue;
+        }
+
+        if (attribute.locations.length === 1) {
+          this.reverseIndex.delete(filterId);
+        } else {
           attribute.locations.splice(index, 1);
         }
       }
     }
+
+    for (const [filterId, lineNumber] of newList) {
+      this.upsert(filterId, {
+        locations: [
+          {
+            name,
+            lineNumber,
+          },
+        ],
+      });
+    }
+
+    this.lists.set(name, newList);
+  }
+
+  public removeList(name: string) {
+    const list = this.lists.get(name);
+    if (list === undefined) {
+      return;
+    }
+
+    for (const [filterId] of list) {
+      const attribute = this.reverseIndex.get(filterId);
+      if (attribute === undefined) {
+        continue;
+      }
+
+      const index = attribute.locations.findIndex(function (location) {
+        return location.name === name;
+      });
+      if (index === -1) {
+        continue;
+      }
+
+      if (attribute.locations.length === 1) {
+        this.reverseIndex.delete(filterId);
+      } else {
+        attribute.locations.splice(index, 1);
+      }
+    }
+    this.lists.delete(name);
   }
 
   public getAttribute(filterId: FilterId): IAttribute | undefined {
-    return this.sourceMap.get(filterId);
+    let attribute = this.reverseIndex.get(filterId);
+    if (attribute !== undefined) {
+      return attribute;
+    }
+
+    attribute = {
+      locations: [],
+    } satisfies IAttribute;
+
+    for (const [name, list] of this.lists) {
+      const lineNumber = list.get(filterId);
+      if (lineNumber !== undefined) {
+        attribute.locations.push({ name, lineNumber });
+      }
+    }
+
+    this.reverseIndex.set(filterId, attribute);
+    return attribute;
   }
 
   public getSerializedSize(): number {

--- a/packages/adblocker/test/attribution.test.ts
+++ b/packages/adblocker/test/attribution.test.ts
@@ -1,0 +1,134 @@
+/*!
+ * Copyright (c) 2017-present Ghostery GmbH. All rights reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import { expect } from 'chai';
+import 'mocha';
+
+import { AttributeProvider, List } from '../src/engine/metadata/attributes.js';
+
+function createList(entries: Array<[number, number]>): List {
+  return new Map(entries);
+}
+
+describe('AttributeProvider', () => {
+  it('adds filters and groups locations by list name', () => {
+    const attributes = new AttributeProvider({});
+
+    attributes.addFilter('ads', 1, 10);
+    attributes.addFilter('trackers', 1, 20);
+
+    expect(attributes.getAttribute(1)).to.eql({
+      locations: [
+        { name: 'ads', lineNumber: 10 },
+        { name: 'trackers', lineNumber: 20 },
+      ],
+    });
+  });
+
+  it('updates an existing location when adding same filter twice', () => {
+    const attributes = new AttributeProvider({});
+
+    attributes.addFilter('ads', 1, 10);
+    attributes.addFilter('ads', 1, 30);
+
+    expect(attributes.getAttribute(1)).to.eql({
+      locations: [{ name: 'ads', lineNumber: 30 }],
+    });
+  });
+
+  it('removes only the requested list from a shared filter', () => {
+    const attributes = new AttributeProvider({});
+
+    attributes.addFilter('ads', 1, 10);
+    attributes.addFilter('trackers', 1, 20);
+
+    attributes.removeFilter('ads', 1);
+
+    expect(attributes.getAttribute(1)).to.eql({
+      locations: [{ name: 'trackers', lineNumber: 20 }],
+    });
+  });
+
+  it('removes the reverse entry when last location is removed', () => {
+    const attributes = new AttributeProvider({});
+
+    attributes.addFilter('ads', 1, 10);
+    attributes.removeFilter('ads', 1);
+
+    expect(attributes.reverseIndex.has(1)).to.be.false;
+    expect(attributes.getAttribute(1)).to.eql({ locations: [] });
+  });
+
+  it('overwrites a list and drops stale locations', () => {
+    const attributes = new AttributeProvider({});
+
+    attributes.addList(
+      'ads',
+      createList([
+        [1, 10],
+        [2, 20],
+      ]),
+    );
+    attributes.addFilter('trackers', 2, 30);
+
+    attributes.addList(
+      'ads',
+      createList([
+        [2, 40],
+        [3, 50],
+      ]),
+    );
+
+    expect(attributes.lists.get('ads')).to.eql(
+      createList([
+        [2, 40],
+        [3, 50],
+      ]),
+    );
+    expect(attributes.getAttribute(1)).to.eql({ locations: [] });
+    expect(attributes.getAttribute(2)).to.eql({
+      locations: [
+        { name: 'ads', lineNumber: 40 },
+        { name: 'trackers', lineNumber: 30 },
+      ],
+    });
+    expect(attributes.getAttribute(3)).to.eql({
+      locations: [{ name: 'ads', lineNumber: 50 }],
+    });
+  });
+
+  it('removes one list without touching the others', () => {
+    const attributes = new AttributeProvider({});
+
+    attributes.addList(
+      'ads',
+      createList([
+        [1, 10],
+        [2, 20],
+      ]),
+    );
+    attributes.addList(
+      'trackers',
+      createList([
+        [2, 30],
+        [3, 40],
+      ]),
+    );
+
+    attributes.removeList('ads');
+
+    expect(attributes.lists.has('ads')).to.be.false;
+    expect(attributes.getAttribute(1)).to.eql({ locations: [] });
+    expect(attributes.getAttribute(2)).to.eql({
+      locations: [{ name: 'trackers', lineNumber: 30 }],
+    });
+    expect(attributes.getAttribute(3)).to.eql({
+      locations: [{ name: 'trackers', lineNumber: 40 }],
+    });
+  });
+});


### PR DESCRIPTION
fixes https://github.com/ghostery/adblocker/issues/5238

Introduce `attribute` to the adblocker engine. This is still very experimental and its implementation detail has not settled down.

**Functionalities**

- [x] Serve line number
- [ ] Derive `IAttribute` into `ICosmeticAttribute` and `INetworkAttribute` to support more fields in cosmetic filters: e.g. `isTrustedScriptlet` and more. (with proper type enforcement)

**Tests**

- [ ] Tests