### PR TITLE
fix: include `removeparam` when merging

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -681,6 +681,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       ...this.redirects.getFilters(),
       ...this.csp.getFilters(),
       ...this.hideExceptions.getFilters(),
+      ...this.removeparams.getFilters(),
     ];
 
     for (const filter of this.htmlFilters.getFilters()) {

--- a/packages/adblocker/test/engine/engine.test.ts
+++ b/packages/adblocker/test/engine/engine.test.ts
@@ -2124,6 +2124,14 @@ foo.com###selector
         ]).getFilters();
         expect(filters).to.have.property('networkFilters').that.have.length(1);
       });
+
+      it('merges $removeparam', () => {
+        const filters = FilterEngine.merge([
+          FilterEngine.parse('foo$removeparam=zar'),
+          FilterEngine.parse('bar'),
+        ]).getFilters();
+        expect(filters).to.have.property('networkFilters').that.have.length(2);
+      });
     });
 
     context('with cosmetic filters', () => {


### PR DESCRIPTION
In the previous version, `merge` function was not including `removeparam` bucket. This includes the bucket.