### PR TITLE
fix: engine size mismatch

### DIFF
--- a/packages/adblocker/src/engine/engine.ts
+++ b/packages/adblocker/src/engine/engine.ts
@@ -566,7 +566,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
    */
   public getSerializedSize(): number {
     let estimatedSize: number =
-      sizeOfByte() + // engine version
+      sizeOfByte() * 2 + // engine version
       this.config.getSerializedSize() +
       this.resources.getSerializedSize() +
       this.preprocessors.getSerializedSize() +
@@ -582,6 +582,7 @@ export default class FilterEngine extends EventEmitter<EngineEventHandlers> {
       4; // checksum
 
     // Estimate size of `this.lists` which stores information of checksum for each list.
+    estimatedSize += sizeOfByte() * 2; // list size
     for (const [name, checksum] of this.lists) {
       estimatedSize += sizeOfASCII(name) + sizeOfASCII(checksum);
     }


### PR DESCRIPTION
This is 6 years old bug. Probably other components did allow extra space. Engine version and size of list are both uint16 but engine's assuming they're uint8 in `getSerializedSize`.