### PR TITLE
perf: reuse TextDecoder and TextEncoder

### DIFF
--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -85,6 +85,11 @@ function usePushScriptsInjection() {
 }
 const USE_PUSH_SCRIPTS_INJECTION = usePushScriptsInjection();
 
+let TEXT_ENCODER: TextEncoder;
+if (typeof TextEncoder !== 'undefined') {
+  TEXT_ENCODER = new TextEncoder();
+}
+
 /**
  * Create an instance of `Request` from WebRequest details.
  */
@@ -243,7 +248,6 @@ export function filterRequestHTML(
   // Create filter to observe loading of resource
   const filter = filterResponseData(request.id) as StreamFilter;
   const decoder = new TextDecoder();
-  const encoder = new TextEncoder();
   const htmlFilter = new StreamingHtmlFilter(rules);
   let accumulatedBufferSize = 0;
 
@@ -258,7 +262,7 @@ export function filterRequestHTML(
         htmlFilter.write(decoder.decode()) +
         htmlFilter.flush(accumulatedBufferSize < MAXIMUM_RESPONSE_BUFFER_SIZE);
       if (remaining.length !== 0) {
-        filter.write(encoder.encode(remaining));
+        filter.write(TEXT_ENCODER.encode(remaining));
       }
     } catch (ex) {
       // If we reach this point, there is probably no way we can recover...
@@ -290,7 +294,9 @@ export function filterRequestHTML(
     }
 
     try {
-      filter.write(encoder.encode(htmlFilter.write(decoder.decode(event.data, { stream: true }))));
+      filter.write(
+        TEXT_ENCODER.encode(htmlFilter.write(decoder.decode(event.data, { stream: true }))),
+      );
     } catch (ex) {
       // If we fail to decode a chunk, we need to be extra conservative and stop
       // listening to streaming response. Teardown takes care of flushing any

--- a/packages/adblocker-webextension/src/index.ts
+++ b/packages/adblocker-webextension/src/index.ts
@@ -85,10 +85,7 @@ function usePushScriptsInjection() {
 }
 const USE_PUSH_SCRIPTS_INJECTION = usePushScriptsInjection();
 
-let TEXT_ENCODER: TextEncoder;
-if (typeof TextEncoder !== 'undefined') {
-  TEXT_ENCODER = new TextEncoder();
-}
+const TEXT_ENCODER = new TextEncoder();
 
 /**
  * Create an instance of `Request` from WebRequest details.
@@ -522,15 +519,12 @@ export class WebExtensionBlocker extends FiltersEngine {
    * 1. Request is 'main_frame'
    * 2. `enableHtmlFiltering` is set to `true`.
    * 3. `browser.webRequest.filterResponseData` (Firefox only!).
-   * 4. `TextEncoder` and `TextDecoder` are available.
    */
   public performHTMLFiltering(browser: Browser, request: Request): void {
     if (
       this.config.enableHtmlFiltering === true &&
       browser.webRequest !== undefined &&
-      browser.webRequest.filterResponseData !== undefined &&
-      typeof TextDecoder !== 'undefined' &&
-      typeof TextEncoder !== 'undefined'
+      browser.webRequest.filterResponseData !== undefined
     ) {
       const htmlFilters = this.getHtmlFilters(request);
       if (htmlFilters.length !== 0) {

--- a/packages/adblocker/src/data-view.ts
+++ b/packages/adblocker/src/data-view.ts
@@ -19,8 +19,8 @@ export const EMPTY_UINT32_ARRAY = new Uint32Array(0);
 // Check if current architecture is little endian
 const LITTLE_ENDIAN: boolean = new Int8Array(new Int16Array([1]).buffer)[0] === 1;
 
-// TextEncoder doesn't need to be recreated every time unlike TextDecoder
 const TEXT_ENCODER = new TextEncoder();
+const TEXT_DECODER = new TextDecoder('utf8', { ignoreBOM: true });
 
 // Store compression in a lazy, global singleton
 let getCompressionSingleton: () => Compression = () => {
@@ -412,9 +412,7 @@ export class StaticDataView {
   public getUTF8(): string {
     const byteLength = this.getLength();
     this.pos += byteLength;
-    return new TextDecoder('utf8', { ignoreBOM: true }).decode(
-      this.buffer.subarray(this.pos - byteLength, this.pos),
-    );
+    return TEXT_DECODER.decode(this.buffer.subarray(this.pos - byteLength, this.pos));
   }
 
   public pushASCII(str: string): void {
@@ -518,9 +516,7 @@ export class StaticDataView {
 
   public getRawCosmetic(): string {
     if (this.compression !== undefined) {
-      return new TextDecoder('utf8', { ignoreBOM: true }).decode(
-        this.compression.cosmeticRaw.decompressRaw(this.getBytes()),
-      );
+      return TEXT_DECODER.decode(this.compression.cosmeticRaw.decompressRaw(this.getBytes()));
     }
     return this.getUTF8();
   }
@@ -535,9 +531,7 @@ export class StaticDataView {
 
   public getRawNetwork(): string {
     if (this.compression !== undefined) {
-      return new TextDecoder('utf8', { ignoreBOM: true }).decode(
-        this.compression.networkRaw.decompressRaw(this.getBytes()),
-      );
+      return TEXT_DECODER.decode(this.compression.networkRaw.decompressRaw(this.getBytes()));
     }
     return this.getUTF8();
   }


### PR DESCRIPTION
`TextDecoder` can be reused if **streaming is not used**. Our `deserialisation` code path initiates `TextDecoder` always. The previous change related to this only reused `TextEncoder` because I decided to create `TextDecoder` every time because it was not safe just looking at the spec.

From internal benchmarking script:

```
master            c578dd184b19c48ffb2da2ae16d187ba76b3b7c2 119 ops/sec
reuse-textdecoder 63c9d72dc8b9acaaf250e6a6cd10b2d4bdd28a30 121 ops/sec
```

It's marginal here, but still worth doing it for extra improvement.