### PR TITLE
Fix local build error

### DIFF
--- a/packages/adblocker-webextension-example/tsconfig.json
+++ b/packages/adblocker-webextension-example/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "types": ["chrome"],
-    "outDir": "dist"
+    "outDir": "dist",
+    "module": "NodeNext"
   },
   "references": [
     { "path": "../adblocker-webextension/tsconfig.json" },


### PR DESCRIPTION
Not sure if this is needed (some unintended interaction between Rollup and TypeScript). But locally, I get this error without it:

```
$ yarn build
lerna notice cli v9.0.7

   ✔  @ghostery/adblocker-extended-selectors:build (2s)
   ✔  @ghostery/adblocker-content:build (3s)
   ✔  @ghostery/adblocker-webextension-cosmetics:build (2s)
   ✔  @ghostery/adblocker-electron-preload:build (3s)
   ✔  @ghostery/adblocker:build (5s)
   ✔  @ghostery/adblocker-webextension:build (2s)
   ✔  @ghostery/adblocker-puppeteer:build (3s)
   ✔  @ghostery/adblocker-electron:build (3s)
   ✔  @ghostery/adblocker-playwright:build (3s)

————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
   ✖  @ghostery/adblocker-webextension-example:build

      ./background.ts → ./dist/background.iife.js...
      (!) [plugin typescript] @rollup/plugin-typescript TS5110: Option 'module' must be set to 'NodeNext' when option 'moduleResolution' is set to 'NodeNext'.
      [!] RollupError: background.ts (22:6): 'const' declarations must be initialized (Note that you need plugins to import files that are not JavaScript)
      background.ts (22:6)
      20:  * Keep track of number of network requests altered for each tab
      21:  */
      22: const counter: Map<number, number> = new Map();
                ^
      23:
      24: /**
          at Object.getRollupError (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/parseAst.js:289:41)
          at ParseError.initialise (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:16412:40)
          at convertNode (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:18388:10)
          at convertProgram (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:17624:12)
          at Module.setSource (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:19360:24)
          at ModuleLoader.addModuleSource (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:23128:13)
        [cause] RollupError: 'const' declarations must be initialized
            at Object.getRollupError (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/parseAst.js:289:41)
            at ParseError.initialise (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:16412:40)
            at convertNode (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:18388:10)
            at convertProgram (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:17624:12)
            at Module.setSource (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:19360:24)
            at ModuleLoader.addModuleSource (/home/.snapshots/2026-05-04--18-24-07--113574-21795/phil/github/adblocker/node_modules/rollup/dist/shared/rollup.js:23128:13)
```