### PR TITLE
fix(ci): patch fd-slice overriding Node 26 APIs causing early exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ bench/.bench.json
 
 .changelog/
 .yarn/
+!/.yarn/
+/.yarn/*
+!/.yarn/patches/
+!/.yarn/patches/**
 .tshy/
 .tshy-build/
 .migration-test/

--- a/.yarn/patches/fd-slicer-npm-1.1.0-3cade0050a.patch
+++ b/.yarn/patches/fd-slicer-npm-1.1.0-3cade0050a.patch
@@ -1,0 +1,67 @@
+diff --git a/index.js b/index.js
+index 65d32a3ecb7d22329f5465cb2ef127f70e54be43..2c017a246c7d9fa9579f14e19182167ff3ebae26 100644
+--- a/index.js
++++ b/index.js
+@@ -87,33 +87,32 @@ function ReadStream(context, options) {
+   this.start = options.start || 0;
+   this.endOffset = options.end;
+   this.pos = this.start;
+-  this.destroyed = false;
++  this._hasRef = true;
+ }
+ 
+ ReadStream.prototype._read = function(n) {
+   var self = this;
+-  if (self.destroyed) return;
++  if (!self._hasRef) return;
+ 
+   var toRead = Math.min(self._readableState.highWaterMark, n);
+   if (self.endOffset != null) {
+     toRead = Math.min(toRead, self.endOffset - self.pos);
+   }
+   if (toRead <= 0) {
+-    self.destroyed = true;
+     self.push(null);
+-    self.context.unref();
++    self._unref();
+     return;
+   }
+   self.context.pend.go(function(cb) {
+-    if (self.destroyed) return cb();
++    if (!self._hasRef) return cb();
+     var buffer = new Buffer(toRead);
+     fs.read(self.context.fd, buffer, 0, toRead, self.pos, function(err, bytesRead) {
++      if (!self._hasRef) return cb();
+       if (err) {
+         self.destroy(err);
+       } else if (bytesRead === 0) {
+-        self.destroyed = true;
+         self.push(null);
+-        self.context.unref();
++        self._unref();
+       } else {
+         self.pos += bytesRead;
+         self.push(buffer.slice(0, bytesRead));
+@@ -123,14 +122,17 @@ ReadStream.prototype._read = function(n) {
+   });
+ };
+ 
+-ReadStream.prototype.destroy = function(err) {
+-  if (this.destroyed) return;
+-  err = err || new Error("stream destroyed");
+-  this.destroyed = true;
+-  this.emit('error', err);
++ReadStream.prototype._unref = function() {
++  if (!this._hasRef) return;
++  this._hasRef = false;
+   this.context.unref();
+ };
+ 
++ReadStream.prototype._destroy = function(err, callback) {
++  this._unref();
++  callback(err);
++};
++
+ util.inherits(WriteStream, Writable);
+ function WriteStream(context, options) {
+   options = options || {};

--- a/package.json
+++ b/package.json
@@ -164,5 +164,8 @@
         "color": "#5dbdcc"
       }
     ]
+  },
+  "resolutions": {
+    "fd-slicer@npm:~1.1.0": "patch:fd-slicer@npm%3A1.1.0#~/.yarn/patches/fd-slicer-npm-1.1.0-3cade0050a.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5310,12 +5310,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fd-slicer@npm:~1.1.0":
+"fd-slicer@npm:1.1.0":
   version: 1.1.0
   resolution: "fd-slicer@npm:1.1.0"
   dependencies:
     pend: "npm:~1.2.0"
   checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
+  languageName: node
+  linkType: hard
+
+"fd-slicer@patch:fd-slicer@npm%3A1.1.0#~/.yarn/patches/fd-slicer-npm-1.1.0-3cade0050a.patch":
+  version: 1.1.0
+  resolution: "fd-slicer@patch:fd-slicer@npm%3A1.1.0#~/.yarn/patches/fd-slicer-npm-1.1.0-3cade0050a.patch::version=1.1.0&hash=db7293"
+  dependencies:
+    pend: "npm:~1.2.0"
+  checksum: 10/05dc51707c8326f3e2018a15149919b109539c4e235c5bb272c57b8acd71d58ad5bae7315d543c039de977fbdff491e26a4182da41529f17f4872b5cdb3da675
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Electron installer doesn't work with Node.JS v26 as fd-slice under yauzl and extract-zip is writing to the newly introduced official public property: `Readable.destroyed`, resulting in the early-exit.

```js
self.destroyed = true;
```

This introduces a patch in the yarn level, so the Electron installer can run with patched code without additional edits.