### PR TITLE
chore(ci): improve test time by skipping playwright deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
         run: yarn lint
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install
 
       - name: Test
         run: yarn test


### PR DESCRIPTION
Playwright’s Ubuntu 24.04 Chromium deps mostly overlap with what Chrome/Chromium themselves need, so those shared libs are very likely already present.

This is pre-step for https://github.com/ghostery/adblocker/pull/5658 and might skip node v26 test.