### PR TITLE
fix(ci): drop 26 from the test pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [22, 24, 26]
+        node: [22, 24]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
There are some packages holding the 26 migration. It's primarily because they rely on and have an expectation of the old API specs. Since the API spec was upgraded already long time ago, what I see the ideal approach as to upgrade those packages rather keeping the backward-compatibility. However, those packages are so widely used that resulting in many breakages in overall. I would wait for Node.JS operational decisions on this and remove the 26 target for now.

The core adblocker engine is not affected by this but satellite packages like adblocker-electron and adblocker-puppeteer are affected. Electron defines their supported engine version range to even number LTS releases (so 26 becomes "active" when they gets "LTS" label).

refs https://github.com/ghostery/adblocker/issues/5581