### PR TITLE
fix: NetworkFilter.toString returning $sub_frame

### DIFF
--- a/packages/adblocker/src/filters/network.ts
+++ b/packages/adblocker/src/filters/network.ts
@@ -1569,11 +1569,19 @@ export default class NetworkFilter implements IFilter {
 
       if (numberOfNegatedOptions < numberOfCptOptions) {
         for (const type of getListOfRequestTypesNegated(this)) {
-          options.push(`~${type}`);
+          if (type === 'sub_frame') {
+            options.push('~subdocument');
+          } else {
+            options.push(`~${type}`);
+          }
         }
       } else {
         for (const type of getListOfRequestTypes(this)) {
-          options.push(type);
+          if (type === 'sub_frame') {
+            options.push('subdocument');
+          } else {
+            options.push(type);
+          }
         }
       }
     }


### PR DESCRIPTION
$sub_frame is not recognised by any syntax standard.

courtesy @smalluban 