### PR TITLE
fix: explicit preprocessor conditions and parenthesis parsing

### DIFF
--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -177,11 +177,8 @@ export function parseFilters(
     let line = lines[i];
 
     // Check if `line` should be left-trimmed
-    if (
-      line.length !== 0 &&
-      (line.charCodeAt(0) <= 32 || line.charCodeAt(line.length - 1) <= 32)
-    ) {
-      line = line.trim();
+    if (line.length !== 0 && line.charCodeAt(0) <= 32) {
+      line = line.trimStart();
     }
 
     // Handle continuations
@@ -208,6 +205,11 @@ export function parseFilters(
           break;
         }
       }
+    }
+
+    // Check if `line` should be right-trimmed
+    if (line.length !== 0 && line.charCodeAt(line.length - 1) <= 32) {
+      line = line.trimEnd();
     }
 
     // Detect if filter is supported, network or cosmetic

--- a/packages/adblocker/src/lists.ts
+++ b/packages/adblocker/src/lists.ts
@@ -177,7 +177,10 @@ export function parseFilters(
     let line = lines[i];
 
     // Check if `line` should be left-trimmed
-    if (line.length !== 0 && line.charCodeAt(0) <= 32) {
+    if (
+      line.length !== 0 &&
+      (line.charCodeAt(0) <= 32 || line.charCodeAt(line.length - 1) <= 32)
+    ) {
       line = line.trim();
     }
 
@@ -205,11 +208,6 @@ export function parseFilters(
           break;
         }
       }
-    }
-
-    // Check if `line` should be right-trimmed
-    if (line.length !== 0 && line.charCodeAt(line.length - 1) <= 32) {
-      line = line.trim();
     }
 
     // Detect if filter is supported, network or cosmetic

--- a/packages/adblocker/src/preprocessor.ts
+++ b/packages/adblocker/src/preprocessor.ts
@@ -53,11 +53,11 @@ export function detectPreprocessor(line: string) {
     return PreprocessorTokens.BEGIF;
   }
 
-  if (line.startsWith('!#else')) {
+  if (line === '!#else') {
     return PreprocessorTokens.ELSE;
   }
 
-  if (line.startsWith('!#endif')) {
+  if (line === '!#endif') {
     return PreprocessorTokens.ENDIF;
   }
 
@@ -161,7 +161,7 @@ export const evaluate = (expression: string, env: Env): boolean => {
   }
 
   // If there is incomplete parenthesis
-  if (stack[0] === '(' || stack[0] === ')') {
+  if (stack.includes('(')) {
     return false;
   }
 

--- a/packages/adblocker/test/lists.test.ts
+++ b/packages/adblocker/test/lists.test.ts
@@ -292,6 +292,18 @@ describe('#parseFilters', () => {
       expect(result).to.have.property('preprocessors').that.have.lengthOf(1);
       expect(result).to.have.property('networkFilters').that.have.lengthOf(1);
     });
+
+    it('handles preprocessors with trailing whitespace', () => {
+      const result = parseFilters(
+        `!#if true   
+||foo.com
+!#endif   `,
+        config,
+      );
+
+      expect(result).to.have.property('preprocessors').that.have.lengthOf(1);
+      expect(result).to.have.property('networkFilters').that.have.lengthOf(1);
+    });
   });
 });
 

--- a/packages/adblocker/test/lists.test.ts
+++ b/packages/adblocker/test/lists.test.ts
@@ -143,9 +143,9 @@ bar.co.uk^*baz
   });
 
   it('handles continued filters with surrounding whitespace', () => {
-    expect(getLinesWithFilters('  ||foo.com^$domain=example.com| \\' + '\n    example.org   ')).to.eql(
-      new Set(['||foo.com^$domain=example.com|example.org']),
-    );
+    expect(
+      getLinesWithFilters('  ||foo.com^$domain=example.com| \\' + '\n    example.org   '),
+    ).to.eql(new Set(['||foo.com^$domain=example.com|example.org']));
   });
 });
 
@@ -301,7 +301,7 @@ describe('#parseFilters', () => {
 
     it('handles preprocessors with trailing whitespace', () => {
       const result = parseFilters(
-        `!#if true   
+        `!#if true
 ||foo.com
 !#endif   `,
         config,

--- a/packages/adblocker/test/lists.test.ts
+++ b/packages/adblocker/test/lists.test.ts
@@ -141,6 +141,12 @@ bar.co.uk^*baz
       `),
     ).to.eql(new Set(['||foo.com']));
   });
+
+  it('handles continued filters with surrounding whitespace', () => {
+    expect(getLinesWithFilters('  ||foo.com^$domain=example.com| \\' + '\n    example.org   ')).to.eql(
+      new Set(['||foo.com^$domain=example.com|example.org']),
+    );
+  });
 });
 
 describe('#parseFilters', () => {

--- a/packages/adblocker/test/preprocessor.test.ts
+++ b/packages/adblocker/test/preprocessor.test.ts
@@ -66,6 +66,7 @@ describe('conditions', () => {
     expect(evaluate('(true', env)).to.be.false;
     expect(evaluate('((true)', env)).to.be.false;
     expect(evaluate('true((true)', env)).to.be.false;
+    expect(evaluate('true&&(false||true', env)).to.be.false;
   });
 });
 
@@ -150,6 +151,38 @@ describe('preprocessors', () => {
 !#else
 ||bar.com^
 !#endif`);
+  });
+
+  it('requires exact else and endif tokens', () => {
+    const invalidElseEngine = FilterEngine.parse(
+      `!#if false
+||bar.com^
+!#else invalid
+||foo.com^
+!#endif`,
+      {
+        loadPreprocessors: true,
+      },
+    );
+    invalidElseEngine.updateEnv(env);
+
+    expect(invalidElseEngine.match(requests.foo)).to.have.property('match', false);
+    expect(invalidElseEngine.match(requests.bar)).to.have.property('match', false);
+
+    const invalidEndifEngine = FilterEngine.parse(
+      `!#if false
+||bar.com^
+!#endif invalid
+||foo.com^
+!#endif`,
+      {
+        loadPreprocessors: true,
+      },
+    );
+    invalidEndifEngine.updateEnv(env);
+
+    expect(invalidEndifEngine.match(requests.foo)).to.have.property('match', false);
+    expect(invalidEndifEngine.match(requests.bar)).to.have.property('match', false);
   });
 
   it('resolves nested conditions', () => {


### PR DESCRIPTION
- String.prototype.trim() trims both side - updated to use trimStart and trimEnd instead.
- Preprocessor condition may see !#elsesomething as !#else as there's no additional checks.
- Fix parenthesis parsing - there should be no parenthesis in stack as they must be consumed beforehands.