### PR TITLE
fix(ci): electron install faliure and reintroduce node v26 again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [22, 24]
+        node: [22, 24, 26]
         os: [ubuntu-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     ]
   },
   "resolutions": {
-    "@remusao/counter@npm:^2.1.0": "patch:@remusao/counter@npm%3A2.1.0#~/.yarn/patches/@remusao-counter-npm-2.1.0-3a2b9a70d3.patch"
+    "@remusao/counter@npm:^2.1.0": "patch:@remusao/counter@npm%3A2.1.0#~/.yarn/patches/@remusao-counter-npm-2.1.0-3a2b9a70d3.patch",
+    "yauzl": "^3.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,16 +2801,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*":
-  version: 25.6.2
-  resolution: "@types/node@npm:25.6.2"
-  dependencies:
-    undici-types: "npm:~7.19.0"
-  checksum: 10/a8afba633f651c80ba3c77d711f1b9bde9cd85ba79f5031af18aa9f0f872e9348cc9e1048fd1b0092cb903f028a4ce505a11dac1205e6efff8b0224de3612028
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:25.9.1":
+"@types/node@npm:*, @types/node@npm:25.9.1":
   version: 25.9.1
   resolution: "@types/node@npm:25.9.1"
   dependencies:
@@ -4637,21 +4628,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:*":
-  version: 42.0.1
-  resolution: "electron@npm:42.0.1"
-  dependencies:
-    "@electron/get": "npm:^5.0.0"
-    "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
-  bin:
-    electron: cli.js
-    install-electron: install.js
-  checksum: 10/aff6e787970ba8409f5128ec652bf3db4f7e1f1e0aade2fcf812f7e93b0665e26b0406378b4f964e15dbefa5c743fd5139922a769f6e21b95cb256eadd942d4c
-  languageName: node
-  linkType: hard
-
-"electron@npm:42.2.0":
+"electron@npm:*, electron@npm:42.2.0":
   version: 42.2.0
   resolution: "electron@npm:42.2.0"
   dependencies:
@@ -5242,15 +5219,6 @@ __metadata:
   dependencies:
     reusify: "npm:^1.0.4"
   checksum: 10/ab2fe3a7a108112e7752cfe7fc11683c21e595913a6a593ad0b4415f31dddbfc283775ab66f2c8ccea6ab7cfc116157cbddcfae9798d9de98d08fe0a2c3e97b2
-  languageName: node
-  linkType: hard
-
-"fd-slicer@npm:~1.1.0":
-  version: 1.1.0
-  resolution: "fd-slicer@npm:1.1.0"
-  dependencies:
-    pend: "npm:~1.2.0"
-  checksum: 10/db3e34fa483b5873b73f248e818f8a8b59a6427fd8b1436cd439c195fdf11e8659419404826059a642b57d18075c856d06d6a50a1413b714f12f833a9341ead3
   languageName: node
   linkType: hard
 
@@ -10169,17 +10137,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:>=7.24.0 <7.24.7":
+"undici-types@npm:>=7.24.0 <7.24.7, undici-types@npm:^7.21.0":
   version: 7.24.6
   resolution: "undici-types@npm:7.24.6"
   checksum: 10/defc9538b952e3c15b8526596c591f7c1f0c7605ad27a2b7feddbea7ef2e3003f3eda2cdb051a3cb1a2185e3893100fd9cb925c799db99d48131ea63b5233d10
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:^7.21.0":
-  version: 7.22.0
-  resolution: "undici-types@npm:7.22.0"
-  checksum: 10/692a9ee08327f34e2945647acbec330090a43a381bfc2d723f0ef5bfe3709390d9fa7a3b929384471a72a4494686079851daf1750c26c990ed5f5accbaf2ce0b
   languageName: node
   linkType: hard
 
@@ -10187,13 +10148,6 @@ __metadata:
   version: 7.16.0
   resolution: "undici-types@npm:7.16.0"
   checksum: 10/db43439f69c2d94cc29f75cbfe9de86df87061d6b0c577ebe9bb3255f49b22c50162a7d7eb413b0458b6510b8ca299ac7cff38c3a29fbd31af9f504bcf7fbc0d
-  languageName: node
-  linkType: hard
-
-"undici-types@npm:~7.19.0":
-  version: 7.19.2
-  resolution: "undici-types@npm:7.19.2"
-  checksum: 10/05c34c63444c8caca7137f122b29ed50c1d7d05d1e0b2337f423575d3264054c4a0139e47e82e65723d09b97fcad6d8b0223b3550430a9006cc00e72a1e035bf
   languageName: node
   linkType: hard
 
@@ -10741,13 +10695,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yauzl@npm:^2.10.0":
-  version: 2.10.0
-  resolution: "yauzl@npm:2.10.0"
+"yauzl@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "yauzl@npm:3.3.1"
   dependencies:
     buffer-crc32: "npm:~0.2.3"
-    fd-slicer: "npm:~1.1.0"
-  checksum: 10/1e4c311050dc0cf2ee3dbe8854fe0a6cde50e420b3e561a8d97042526b4cf7a0718d6c8d89e9e526a152f4a9cec55bcea9c3617264115f48bd6704cf12a04445
+    pend: "npm:~1.2.0"
+  checksum: 10/b9ecac2dca8cf0ce83d29e24ab66af50c2488f12630d0778c5190cc3ca898308986a3955fb6bbc8ee6fe21eae1691ec26068760a54d873f3930718be3bbd1ce3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
refs https://github.com/electron/electron/issues/51619
fixes https://github.com/ghostery/adblocker/issues/5581

I wanted to wait the upstream fix but it's now spreading to other node versions, so I'm forcibly bumping the version.