### PR TITLE
fix: normalizedUrl is set too early

### DIFF
--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -413,7 +413,7 @@ export default class Request<T = any | undefined> {
       this.isSupported = false;
     }
 
-    this.normalizedUrl = url.toLowerCase();
+    this.normalizedUrl = this.url.toLowerCase();
   }
 
   public getHostnameHashes(): Uint32Array {

--- a/packages/adblocker/src/request.ts
+++ b/packages/adblocker/src/request.ts
@@ -368,7 +368,6 @@ export default class Request<T = any | undefined> {
     this.type = type;
 
     this.url = url;
-    this.normalizedUrl = url.toLowerCase();
     this.hostname = hostname;
     this.domain = domain;
 
@@ -413,6 +412,8 @@ export default class Request<T = any | undefined> {
       this.isHttps = false;
       this.isSupported = false;
     }
+
+    this.normalizedUrl = url.toLowerCase();
   }
 
   public getHostnameHashes(): Uint32Array {

--- a/packages/adblocker/test/matching.test.ts
+++ b/packages/adblocker/test/matching.test.ts
@@ -302,6 +302,9 @@ describe('#NetworkFilter.match', () => {
       type: 'script',
       url: 'https://qwertyuiopas1234567890.com/bar',
     });
+    // Data URIs and case-sensitivity
+    expect(f`/Ok/`).not.to.matchRequest({ url: 'data:text/plain,Ok' });
+    expect(f`/Ok/$match-case`).not.to.matchRequest({ url: 'data:text/plain,Ok' });
   });
 
   it('options', () => {


### PR DESCRIPTION
fixes https://github.com/ghostery/adblocker/issues/5703

Setting `normalizedUrl` earlier may result in performance degradation and inconsistent behaviour in matching. `checkPattern` function uses this property depending on the case sensitivity and using the full base64 string instead of shorten version would add a computation pressure.