### PR TITLE
docs: fix double space and pluralization in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Ghostery adblocker is a JavaScript library for *blocking ads, trackers, and 
 
 ## Getting Started
 
-The Ghostery adblocker is the easiest and most efficient way to block ads and trackers in your project. Only a few lines of code are required to integrate smoothly with [Puppeteer](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-puppeteer-example), [Electron](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-electron-example), a  Chrome- and Firefox-compatible [browser extension](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-webextension-example), or any environment supporting [JavaScript](https://github.com/ghostery/adblocker/tree/master/packages/adblocker) (e.g. Node.js or React Native).
+The Ghostery adblocker is the easiest and most efficient way to block ads and trackers in your project. Only a few lines of code are required to integrate smoothly with [Puppeteer](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-puppeteer-example), [Electron](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-electron-example), a Chrome- and Firefox-compatible [browser extension](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-webextension-example), or any environment supporting [JavaScript](https://github.com/ghostery/adblocker/tree/master/packages/adblocker) (e.g. Node.js or React Native).
 
 Here is how to do it in two steps for a Chrome- and Firefox-compatible WebExtension:
 1. Install: `npm install --save @ghostery/adblocker-webextension`
@@ -79,7 +79,7 @@ This project makes use of [lerna](https://github.com/lerna/lerna) and [yarn work
 4. Build: `yarn build`,
 5. Test: `yarn test`.
 
-For any question, feel free to [open an issue](https://github.com/ghostery/adblocker/issues/new) or a pull request to get some help!
+For any questions, feel free to [open an issue](https://github.com/ghostery/adblocker/issues/new) or a pull request to get some help!
 
 ## Who is using it?
 


### PR DESCRIPTION
## Description
This PR fixes a double space and pluralization in `README.md`.

## Details
1. Removed double space (`a  Chrome- and Firefox-compatible` $\to$ `a Chrome- and Firefox-compatible`).
2. Corrected plural form (`For any question` $\to$ `For any questions`).