### PR TITLE
docs(adblocker-puppeteer): fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The Ghostery adblocker is a JavaScript library for *blocking ads, trackers, and 
 
 ## Getting Started
 
-The Ghostery adblocker is the easiest and most efficient way to block ads and trackers in your project. Only a few lines of code are required to integrate smoothly with [Puppeteer](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-puppeteer-example), [Electron](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-electron-example), a  Chrome- and Firefox-compatible [browser extension](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-webextension-example), or any environment supporting [JavaScript](https://github.com/ghostery/adblocker/tree/master/packages/adblocker) (e.g. Node.js or React Native).
+The Ghostery adblocker is the easiest and most efficient way to block ads and trackers in your project. Only a few lines of code are required to integrate smoothly with [Puppeteer](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-puppeteer-example), [Electron](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-electron-example), a Chrome- and Firefox-compatible [browser extension](https://github.com/ghostery/adblocker/tree/master/packages/adblocker-webextension-example), or any environment supporting [JavaScript](https://github.com/ghostery/adblocker/tree/master/packages/adblocker) (e.g. Node.js or React Native).
 
 Here is how to do it in two steps for a Chrome- and Firefox-compatible WebExtension:
 1. Install: `npm install --save @ghostery/adblocker-webextension`
@@ -79,7 +79,7 @@ This project makes use of [lerna](https://github.com/lerna/lerna) and [yarn work
 4. Build: `yarn build`,
 5. Test: `yarn test`.
 
-For any question, feel free to [open an issue](https://github.com/ghostery/adblocker/issues/new) or a pull request to get some help!
+For any questions, feel free to [open an issue](https://github.com/ghostery/adblocker/issues/new) or a pull request to get some help!
 
 ## Who is using it?
 

--- a/packages/adblocker-puppeteer/README.md
+++ b/packages/adblocker-puppeteer/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Pupeteer Adblocker</h2>
+<h1 align="center">Puppeteer Adblocker</h1>
 
 <p align="center">
   <em>

--- a/packages/adblocker/README.md
+++ b/packages/adblocker/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Adblocker</h2>
+<h1 align="center">Adblocker</h1>
 
 <p align="center">
   <em>
@@ -87,7 +87,7 @@ const { match } = engine.match(Request.fromRawDetails({
 ### Request Abstraction
 
 To abstract over network requests independently from platforms (Node.js,
-WebExtension, etc.), the `Request` provides a unified APIs and helpers functions
+WebExtension, etc.), `Request` provides unified APIs and helper functions
 for initialization on different platforms:
 
 ```javascript


### PR DESCRIPTION
## Description
This PR fixes a title spelling typo and mismatched HTML tag in `packages/adblocker-puppeteer/README.md`.

## Details
1. Fixed spelling typo in document title (`Pupeteer` $\to$ `Puppeteer`).
2. Fixed mismatched HTML closing tag (`<h2>` $\to$ `</h1>`).