### PR TITLE
fix(ci): playwright browsers not being found

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         run: yarn lint
 
       - name: Install Playwright browsers
-        run: yarn exec playwright install
+        run: yarn workspace @ghostery/adblocker-playwright exec playwright install
 
       - name: Install Puppeteer browsers
-        run: yarn exec puppeteer browsers install
+        run: yarn workspace @ghostery/adblocker-puppeteer exec puppeteer browsers install
 
       - name: Test
         run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         run: yarn lint
 
       - name: Install Playwright browsers
-        run: yarn playwright install
+        run: yarn exec playwright install
 
       - name: Install Puppeteer browsers
-        run: yarn puppeteer browsers install
+        run: yarn exec puppeteer browsers install
 
       - name: Test
         run: yarn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
         run: yarn lint
 
       - name: Install Playwright browsers
-        run: yarn dlx playwright install
+        run: yarn playwright install
 
       - name: Install Puppeteer browsers
-        run: yarn dlx puppeteer browsers install
+        run: yarn puppeteer browsers install
 
       - name: Test
         run: yarn test


### PR DESCRIPTION
playwright package version from yarn dlx and the local one might mismatch, also letting yarn use the pinned version of puppeteer